### PR TITLE
Feature 2: View Class List

### DIFF
--- a/app/apis/classes.py
+++ b/app/apis/classes.py
@@ -54,7 +54,7 @@ class ClassList(Resource):
     upcoming_classes = class_resource.get_upcoming_classes()
     #If there are no upcoming classes return a message
     if len(upcoming_classes) == 0:
-      return {MSG: "No upcoming classes availible"}, HTTPStatus.OK
+      return {MSG: "No upcoming classes available"}, HTTPStatus.OK
     return {MSG: upcoming_classes}, HTTPStatus.OK
   
   #Creates a new fitness class, endpoint used by trainers and admins, validates inputs and applies upcoming 2 weeks rule


### PR DESCRIPTION
resolves issue #10 
Implement backend support for viewing upcoming fitness classes.  This PR adds an endpoint to retrieve all classes scheduled within the next two weeks, including full classes and remaining spots. The response includes full class details so guests and members can browse available classes before booking.

Notes:
- Classes outside the upcoming two-week window are excluded.
- Fully booked classes are still returned with remaining_spots = 0.
- No filtering or sorting is applied at this stage.