### PR TITLE
Feature 4: Add endpoint to view members booked for a class

### DIFF
--- a/app/db/bookings.py
+++ b/app/db/bookings.py
@@ -26,8 +26,14 @@ class BookingResource:
     def get_user_bookings(self, user_id: str):
         bookings = self.collection.find({USER_ID: user_id})
         return serialize_items(list(bookings))
+    
+    def get_class_bookings(self, class_id: str):
+        bookings = self.collection.find({CLASS_ID: class_id})
+        return serialize_items(list(bookings))
 
     def get_booking(self, user_id: str, class_id: str):
         booking = self.collection.find_one({USER_ID: user_id, CLASS_ID: class_id})
         return serialize_item(booking)
+    
+
 


### PR DESCRIPTION
This PR implements a new endpoint that allows trainers to view the list of members who have booked a specific fitness class.

#### Endpoint:
`GET /classes/<class_id>/members`

#### Changes Made:
- Trainer-only endpoint under the `classes` namespace.
- JWT authentication required.
- Role-based authorization check.
- Retrieval of all bookings for the specified class.
- Lookup of corresponding user records.
- Response returns a list of unique members (no duplicates).

#### Validation & Authorization

- Requires valid JWT token.
- Returns 403 if user is not a trainer or admin.
- Returns 404 if the class does not exist.

Closes #19 