### PR TITLE
fix: correct function call to get_upcoming_classes_grouped_by_week()

### DIFF
--- a/app/apis/classes.py
+++ b/app/apis/classes.py
@@ -134,7 +134,7 @@ class ClassList(Resource):
       return {MSG:"End time must be after start time"}, HTTPStatus.NOT_ACCEPTABLE
     
     #Prevent class overlap: two classes at same time at same location
-    existing_classes = ClassResource().get_upcoming_classes()
+    existing_classes = ClassResource().get_upcoming_classes_grouped_by_week()
     for c in existing_classes:
       if c.get(location)!=location_value:
         continue


### PR DESCRIPTION
Fixes a typo in the function call by replacing `get_upcoming_classes()` with `get_upcoming_classes_grouped_by_week()`