### PR TITLE
fix: return empty list when no bookings exist

### DIFF
--- a/app/apis/classes.py
+++ b/app/apis/classes.py
@@ -211,9 +211,6 @@ class ClassMembers(Resource):
       booking_res = BookingResource()
       bookings = booking_res.get_class_bookings(class_id)
 
-      if not bookings:
-        return {MSG: "No members are registered for this class"}, HTTPStatus.OK 
-
       # loop bookings to fetch user records
       result = []
       seen = set()


### PR DESCRIPTION
Removed the return that was added to the get class members endpoint 
when no bookings exist. Empty bookings now falls through the loop and returns `[]` as before.