### PR TITLE
CI Setup - add GitHub Actions workflow and README badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: 
+      - main
+  pull_request:
+    branches: 
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Run tests with coverage
+        env:
+          MONGO_URI: ${{ secrets.MONGO_URI }}
+          DB_NAME: ${{ secrets.DB_NAME }}
+          MOCK_DB: "true"
+          JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
+          AWS_REGION: "us-east-1"
+          SES_SENDER_EMAIL: "test@example.com"
+        run: |
+          pytest tests/ --cov=app --cov-report=term-missing --cov-fail-under=90

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![CI](https://github.com/cs-uh-2012-spring26/cs-uh-2012-software-engineering-groupproject-group_a/actions/workflows/ci.yml/badge.svg?branch=main)
+
 # Fitness Class Management and Booking System
 
 This repo is a web application for managing gym class schedules, bookings, and trainer–member interactions. It provides role-based access for members, trainers, and admins, with JWT-based authentication and a RESTful API backend.


### PR DESCRIPTION
This sets up the GitHub Actions CI workflow for the project and adds a CI badge to README.md.

The workflow triggers on every push and pull request to main, installs dependencies from requirements-dev.txt, and runs the full test suite with coverage reporting. MOCK_DB is set to true so all tests run against mongomock with no real database or email service calls. The build fails automatically if statement coverage drops below 90%.

Github repository Secrets stores sensitive environment variables (MONGO_URI, DB_NAME, JWT_SECRET_KEY). Dummy values are provided inline for AWS_REGION and SES_SENDER_EMAIL since the email service is mocked in tests.

Notes:
- Workflow file at .github/workflows/ci.yml
- Badge reflects live build status on main branch
- Coverage threshold enforced via --cov-fail-under=90

Closes #46 