### PR TITLE
Add Sprint Changelog (for sprint 1 -> 2) and Update samplenv

### DIFF
--- a/.samplenv
+++ b/.samplenv
@@ -13,7 +13,12 @@
 # database configs
 MONGO_URI="mongodb://localhost:27017"
 DB_NAME="eventsref_dev"
-MOCK_DB="false"
+MOCK_DB="true"
 
 # server config
 DEBUG="true"
+JWT_SECRET_KEY="this-is-a-long-enough-secret-key-for-testing"
+
+# email config
+AWS_REGION=us-east-1
+SES_SENDER_EMAIL=test@example.com

--- a/reports/requirements.md
+++ b/reports/requirements.md
@@ -181,6 +181,15 @@ This clarification directly impacted our backend design by requiring authenticat
 
 ---
 
+# 3. Sprint Changelog
+
+## Sprint 1 → Sprint 2 Updates
+
+> Sprint 2 introduced Feature 5 (Send Reminder Emails), unit tests for all features, and CI integration. The following are corrections made to Sprint 1 deliverables:
+
+- Fixed a typo in the function call by replacing `get_upcoming_classes()` with `get_upcoming_classes_grouped_by_week()`
+- Updated the UML Use Case Diagram to reflect feedback and current system design
+- Assigned owners to previously unassigned Sprint 1 GitHub issues
 
 
 

--- a/reports/requirements.md
+++ b/reports/requirements.md
@@ -187,7 +187,7 @@ This clarification directly impacted our backend design by requiring authenticat
 
 > Sprint 2 introduced Feature 5 (Send Reminder Emails), unit tests for all features, and CI integration. The following are corrections made to Sprint 1 deliverables:
 
-- Fixed a typo in the function call by replacing `get_upcoming_classes()` with `get_upcoming_classes_grouped_by_week()`
+- Fixed a typo in the function call by replacing `get_upcoming_classes()` with `get_upcoming_classes_grouped_by_week()` ([#30](https://github.com/cs-uh-2012-spring26/cs-uh-2012-software-engineering-groupproject-group_a/pull/30))
 - Updated the UML Use Case Diagram to reflect feedback and current system design
 - Assigned owners to previously unassigned Sprint 1 GitHub issues
 


### PR DESCRIPTION
- Added Sprint 1 → Sprint 2 changelog section to `requirements.md`, covering fixes to Sprint 1 deliverables 
- Added `AWS_REGION` and `SES_SENDER_EMAIL` to `.sampleenv` so local setup requirements are documented for viewers
