### PR TITLE
Refactor auth and role flows for admin/trainer 

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,35 +100,60 @@ deactivate
 
 This API uses JWT-based authentication to protect certain endpoints.
 
-### Pre-seeded Trainer Account
 
-A trainer account is automatically created when the application starts.
-
-**Trainer Credentials:**
-
-- Username: `trainer1`
-- Password: `password123`
 
 ---
 
-## How to Test Trainer-Only Endpoints in Swagger
+## How Admin & Trainer accounts work
+Both admin and trainer log in with email + password using the same /auth/login endpoint.\
+The admin account is pre-seeded when the app starts.\
+Only the admin can register new trainers (via the admin‑protected trainer registration endpoint).
+Only admin and trainers can:
+- create classes,
+- view classes,
+- send reminders for their classes.
 
-- Start the server following the instructions above.
-- Open Swagger UI in your browser.
-- Navigate to `POST /auth/login`.
-- Login using: 
+### Pre-seeded Admin Account
+An admin account is automatically created when the application starts.
+
+**Admin Credentials:**
+- Username: `admin1`
+- Email: `admin1@test.com`
+- Password: `password123`
+
+## How to Test Admin & Trainer Flows in Swagger
+Log in as the pre-seeded admin:
+1. Start the server following the instructions above.
+2. Open Swagger UI in your browser.
+3. Navigate to `POST /auth/login`.
+4. Log in using: 
 {
-  "username": "trainer1",
+  "email": "admin1@test.com",
   "password": "password123"
 }
-5. Copy the access_token from the response.
-6. Click the Authorize button in Swagger.
+5. Copy the `access_token` from the response.
+6. Click the Authorize button in Swagger (top-right).
 7. Paste the token in the following format:
 `Bearer <your_access_token>`
+8. Click authorize and close. You are now authenticated as admin.
+
+Register a Trainer (admin only):
+1. Navigate to `POST /auth/register/trainer`.
+2. Provide the trainer details, and send the request. If you try this without an admin token, you’ll get a 403 Admin access required error.
+
+Log in as a Trainer:
+1. Log out of existing Swagger authorization (Authorize -> Logout)
+2. Navigate to `POST /auth/login`.
+3. Log in using registered trainer credentials.
+4. Copy trainer's `access_token` from the response.
+5. Click the Authorize button in Swagger (top-right).
+6. Paste the token in the following format:
+`Bearer <your_access_token>`
+7. Click authorize and close. You are now authenticated as trainer.
 8. You can now access protected endpoints such as:
-- `POST /classes/` (Create Class – trainer only)
-- `GET /classes/{class_id}/members` (View Class Members – trainer only)
-- `POST /classes/{class_id}/reminders` (Send Reminder Emails – trainer only)
+- `POST /classes/` (Create Class – admin/trainer only)
+- `GET /classes/{class_id}/members` (View Class Members – admin/trainer only)
+- `POST /classes/{class_id}/reminders` (Send Reminder Emails – admin/trainer only)
 
 ## Email Configuration (Amazon SES)
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,7 +3,7 @@ from app.apis.classes import api as classes_ns
 from app.apis.auth import api as auth_ns
 from app.apis.bookings import api as bookings_ns
 from werkzeug.security import generate_password_hash
-from app.db.users import UserResource
+from app.db.users import UserResource, Role
 from app.config import Config
 from app.db import DB
 
@@ -21,13 +21,13 @@ def create_app():
     DB.init_app(app)
 
     user_res = UserResource()
-    if not user_res.get_user_by_username("trainer1"):
+    if not user_res.get_user_by_email("admin1@test.com"):
         user_res.create_user(
-            "trainer1",
-            "trainer1@test.com",
+            "admin1",
+            "admin1@test.com",
             generate_password_hash("password123"),
             "+971500000999",
-            role="trainer",
+            role=Role.ADMIN,
         )
     
     jwt = JWTManager(app)

--- a/app/apis/auth.py
+++ b/app/apis/auth.py
@@ -31,13 +31,14 @@ REGISTER_USER = api.model(
         EMAIL: fields.String(required=True, example=_EXAMPLE_USER_1[EMAIL]),
         "password": fields.String(required=True, example=_EXAMPLE_USER_1["password"]),
         PHONE: fields.String(required=True, example=_EXAMPLE_USER_1[PHONE]),
+        ROLE: fields.String(required=False, enum=["member", "trainer", "admin"], example="member", description="Defaults to member"),
     },
 )
 
 LOGIN_USER = api.model(
     "Login",
     {
-        USERNAME: fields.String(required=True, example=_EXAMPLE_USER_1[USERNAME]),
+        EMAIL: fields.String(required=True, example=_EXAMPLE_USER_1[EMAIL]),
         "password": fields.String(required=True, example=_EXAMPLE_USER_1["password"]),
     },
 )
@@ -60,10 +61,11 @@ class Register(Resource):
         password = request.json.get("password")
         phone = request.json.get(PHONE)
         user_res = UserResource()
+        role = user_res.parse_role(request.json.get(ROLE))
         if user_res.get_user_by_username(username) or user_res.get_user_by_email(email):
             return {MSG: "Username or email already exists"}, HTTPStatus.BAD_REQUEST
         password_hash = generate_password_hash(password)
-        user_id = user_res.create_user(username, email, password_hash, phone, role="member")
+        user_id = user_res.create_user(username, email, password_hash, phone, role)
 
         return {MSG: f"User created with id: {user_id}"}, HTTPStatus.CREATED
 
@@ -73,11 +75,11 @@ class Login(Resource):
     @api.response(HTTPStatus.OK, "Login successful", TOKEN_MODEL)
     @api.response(HTTPStatus.UNAUTHORIZED, "Invalid credentials")
     def post(self):
-        username = request.json.get(USERNAME)
+        email = request.json.get(EMAIL)
         password = request.json.get("password")
 
         user_res = UserResource()
-        user = user_res.get_user_by_username(username)
+        user = user_res.get_user_by_email(email)
         if user is None:
             return {MSG: "Invalid credentials"}, HTTPStatus.UNAUTHORIZED
 

--- a/app/apis/auth.py
+++ b/app/apis/auth.py
@@ -1,11 +1,11 @@
 from flask_restx import Namespace, Resource, fields
 from app.apis import MSG
 from app.db.users import UserResource
-from app.db.users import USERNAME, EMAIL, PASSWORD_HASH, PHONE, ROLE
+from app.db.users import USERNAME, EMAIL, PASSWORD_HASH, PHONE, Role
 from http import HTTPStatus
 from flask import request
 from werkzeug.security import generate_password_hash, check_password_hash
-from flask_jwt_extended import create_access_token
+from flask_jwt_extended import create_access_token, jwt_required, get_jwt_identity
 
 
 api = Namespace("auth", description="Authentication endpoints")
@@ -31,7 +31,6 @@ REGISTER_USER = api.model(
         EMAIL: fields.String(required=True, example=_EXAMPLE_USER_1[EMAIL]),
         "password": fields.String(required=True, example=_EXAMPLE_USER_1["password"]),
         PHONE: fields.String(required=True, example=_EXAMPLE_USER_1[PHONE]),
-        ROLE: fields.String(required=False, enum=["member", "trainer", "admin"], example="member", description="Defaults to member"),
     },
 )
 
@@ -50,8 +49,8 @@ TOKEN_MODEL = api.model(
     },
 )
 
-@api.route("/register")
-class Register(Resource):
+@api.route("/register/member")
+class RegisterMember(Resource):
     @api.expect(REGISTER_USER, validate=True)
     @api.response(HTTPStatus.CREATED, "User registered")
     @api.response(HTTPStatus.BAD_REQUEST, "Username or email already exists")
@@ -61,13 +60,37 @@ class Register(Resource):
         password = request.json.get("password")
         phone = request.json.get(PHONE)
         user_res = UserResource()
-        role = user_res.parse_role(request.json.get(ROLE))
         if user_res.get_user_by_username(username) or user_res.get_user_by_email(email):
             return {MSG: "Username or email already exists"}, HTTPStatus.BAD_REQUEST
         password_hash = generate_password_hash(password)
-        user_id = user_res.create_user(username, email, password_hash, phone, role)
+        user_id = user_res.create_user(username, email, password_hash, phone, role=Role.MEMBER)
 
-        return {MSG: f"User created with id: {user_id}"}, HTTPStatus.CREATED
+        return {MSG: f"Member created with id: {user_id}"}, HTTPStatus.CREATED
+    
+@api.route("/register/trainer")
+class RegisterTrainer(Resource):
+    @jwt_required()
+    @api.expect(REGISTER_USER, validate=True)
+    @api.response(HTTPStatus.CREATED, "User registered")
+    @api.response(HTTPStatus.BAD_REQUEST, "Username or email already exists")
+    def post(self):
+        user_id = get_jwt_identity()
+        user_res = UserResource()
+        user = user_res.get_user_by_id(user_id)
+        if user is None or not user_res.is_admin(user):
+            return {MSG: "Admin access required"}, HTTPStatus.FORBIDDEN
+        
+        username = request.json.get(USERNAME)
+        email = request.json.get(EMAIL)
+        password = request.json.get("password")
+        phone = request.json.get(PHONE)
+
+        if user_res.get_user_by_username(username) or user_res.get_user_by_email(email):
+            return {MSG: "Username or email already exists"}, HTTPStatus.BAD_REQUEST
+        password_hash = generate_password_hash(password)
+        user_id = user_res.create_user(username, email, password_hash, phone, role=Role.TRAINER)
+
+        return {MSG: f"Trainer created with id: {user_id}"}, HTTPStatus.CREATED
 
 @api.route("/login")
 class Login(Resource):
@@ -88,3 +111,4 @@ class Login(Resource):
 
         access_token = create_access_token(identity=str(user["_id"]))
         return {"access_token": access_token}, HTTPStatus.OK
+

--- a/app/apis/classes.py
+++ b/app/apis/classes.py
@@ -97,7 +97,7 @@ class ClassList(Resource):
     user_id = get_jwt_identity()
     user_res = UserResource()
     user = user_res.get_user_by_id(user_id)
-    if user is None or user.get(ROLE) not in ("trainer", "admin"):
+    if  not user_res.can_create_class(user):
       return {MSG: "Only trainers or admins can create classes"}, HTTPStatus.FORBIDDEN
 
     class_name_value = request.json.get(class_name)

--- a/app/db/classes.py
+++ b/app/db/classes.py
@@ -67,7 +67,10 @@ class ClassResource:
         return None
     class_ = self.collection.find_one({"_id": obj_id})
     return serialize_item(class_)
-
+  
+  def has_remaining_spots(self, class_id):
+    class_obj = self.get_class_by_id(class_id)
+    return bool(class_obj and class_obj.get(remaining_spots, 0) > 0)
 
   def decrement_remaining_spots(self, class_id: str): #decrement remaining spots of a class when a member books it
     from bson import ObjectId

--- a/app/db/users.py
+++ b/app/db/users.py
@@ -24,13 +24,13 @@ class UserResource:
     def __init__(self):
         self.collection = DB.get_collection(USER_COLLECTION)
 
-    def create_user(self, username: str, email: str, password_hash: str, phone: str | None = None, role: str = Role.MEMBER.value):
+    def create_user(self, username: str, email: str, password_hash: str, phone: str | None = None, role: Role = Role.MEMBER):
         user = {
             USERNAME: username,
             EMAIL: email,
             PASSWORD_HASH: password_hash,
             PHONE: phone,
-            ROLE: role,
+            ROLE: role.value,
         }
         result = self.collection.insert_one(user)
         return str(result.inserted_id)
@@ -69,7 +69,7 @@ class UserResource:
         return bool(user) and user.get(ROLE) == Role.ADMIN.value
 
     def can_create_class(self, user):
-        return is_trainer(user) or is_admin(user)
+        return self.is_trainer(user) or self.is_admin(user)
     
 
     

--- a/app/db/users.py
+++ b/app/db/users.py
@@ -1,4 +1,4 @@
-from app.db.utils import serialize_item, serialize_items
+from app.db.utils import serialize_item
 from app.db import DB
 from bson import ObjectId
 from enum import Enum

--- a/app/db/users.py
+++ b/app/db/users.py
@@ -1,6 +1,7 @@
 from app.db.utils import serialize_item, serialize_items
 from app.db import DB
 from bson import ObjectId
+from enum import Enum
 
 # User Collection Name
 USER_COLLECTION = "users"
@@ -12,13 +13,18 @@ PASSWORD_HASH = "password_hash"
 PHONE = "phone"
 ROLE = "role" #"member" ,"trainer", "admin"
 
+class Role(str, Enum):
+    MEMBER = "member"
+    TRAINER = "trainer"
+    ADMIN = "admin"
+
 
 class UserResource:
 
     def __init__(self):
         self.collection = DB.get_collection(USER_COLLECTION)
 
-    def create_user(self, username: str, email: str, password_hash: str, phone: str | None = None, role: str = "member"):
+    def create_user(self, username: str, email: str, password_hash: str, phone: str | None = None, role: str = Role.MEMBER.value):
         user = {
             USERNAME: username,
             EMAIL: email,
@@ -45,3 +51,26 @@ class UserResource:
 
         user = self.collection.find_one({"_id": obj_id}) 
         return serialize_item(user) 
+    
+    def parse_role(self, role):
+        if isinstance(role,Role): #if already a Role enum, use it
+            return role.value
+        if role is None: #else default to MEMBER
+            return Role.MEMBER.value
+        value = str(role).strip().lower() #normalize to string, ex: if parse_role("Trainer")
+        if value not in {r.value for r in Role}:
+            raise ValueError(f"Invalid role: {role}")
+        return value
+    
+    def is_trainer(self, user):
+        return bool(user) and user.get(ROLE) == Role.TRAINER.value
+
+    def is_admin(self, user):
+        return bool(user) and user.get(ROLE) == Role.ADMIN.value
+
+    def can_create_class(self, user):
+        return is_trainer(user) or is_admin(user)
+    
+
+    
+

--- a/tests/unit/test_classes.py
+++ b/tests/unit/test_classes.py
@@ -28,12 +28,12 @@ def clear_classes_collection():
   classes_col = DB.get_collection("classes")
   classes_col.delete_many({})
 
-def get_trainer_auth_header(app_client):
-  #Log in as seeded trainer user and return valid JWT auth header
+def get_admin_auth_header(app_client):
+  #Log in as seeded admin user and return valid JWT auth header
   login_response = app_client.post(
     "/auth/login",
     json ={
-      USERNAME: "trainer1",
+      "email": "admin1@test.com",
       "password": "password123"
     },
   )
@@ -55,7 +55,7 @@ def get_member_auth_header(app_client):
   password = "password123"
 
   #register a new member
-  register_response = app_client.post("/auth/register",
+  register_response = app_client.post("/auth/register/member",
     json = {
       USERNAME : username,
       EMAIL: email,
@@ -69,17 +69,17 @@ def get_member_auth_header(app_client):
   #Log in as that member
   login_response = app_client.post("/auth/login",
     json = {
-      "name": username,
+      "email": email,
       "password": password
     })
   #Make sure login succeded
   assert login_response.status_code == HTTPStatus.OK
 
   #Extract token and return auth header
-  acces_token = login_response.json.get("access_token")
-  assert acces_token is not None
+  access_token = login_response.json.get("access_token")
+  assert access_token is not None
 
-  return {"Authorization": f"Bearer {acces_token}"}
+  return {"Authorization": f"Bearer {access_token}"}
 
 def build_valid_class():
   class_start_time = datetime.now()+timedelta(hours=2) #Done to ensure start date is in the future and within allowed 2-week window
@@ -97,8 +97,8 @@ def build_valid_class():
 
 def test_create_class_success(app_client):
   #Main sucess scenarion for Feature 1
-  #Expected behaviour would be that trainer logs in, submits valid data, API creates class, API returns HTTP 200, response contains created class id
-  auth_headers = get_trainer_auth_header(app_client)
+  #Expected behaviour would be that admin/trainer logs in, submits valid data, API creates class, API returns HTTP 200, response contains created class id
+  auth_headers = get_admin_auth_header(app_client)
   class_payload = build_valid_class()
 
   response = app_client.post("/classes/", json = class_payload, headers = auth_headers )
@@ -109,7 +109,7 @@ def test_create_class_success(app_client):
 
 def test_create_class_with_missing_class_name_fails(app_client):
   #Validation failed; class_name is required
-  auth_headers = get_trainer_auth_header(app_client)
+  auth_headers = get_admin_auth_header(app_client)
   class_payload = build_valid_class()
   class_payload["class_name"] = ""
 
@@ -120,7 +120,7 @@ def test_create_class_with_missing_class_name_fails(app_client):
 
 def test_create_class_with_missing_start_time_fails(app_client):
   #Validation failed; start_time is required
-  auth_headers = get_trainer_auth_header(app_client)
+  auth_headers = get_admin_auth_header(app_client)
   class_payload = build_valid_class()
   class_payload["start_time"] = ""
 
@@ -131,7 +131,7 @@ def test_create_class_with_missing_start_time_fails(app_client):
 
 def test_create_class_with_missing_end_time_fails(app_client):
   #Validation failed; end_time is required
-  auth_headers = get_trainer_auth_header(app_client)
+  auth_headers = get_admin_auth_header(app_client)
   class_payload = build_valid_class()
   class_payload["end_time"] = ""
 
@@ -142,7 +142,7 @@ def test_create_class_with_missing_end_time_fails(app_client):
 
 def test_create_class_with_missing_location_fails(app_client):
   #Validation failed; location is required
-  auth_headers = get_trainer_auth_header(app_client)
+  auth_headers = get_admin_auth_header(app_client)
   class_payload = build_valid_class()
   class_payload["location"] = ""
 
@@ -153,7 +153,7 @@ def test_create_class_with_missing_location_fails(app_client):
 
 def test_create_class_with_missing_trainer_name_fails(app_client):
   #Validation failed; trainer_name is required
-  auth_headers = get_trainer_auth_header(app_client)
+  auth_headers = get_admin_auth_header(app_client)
   class_payload = build_valid_class()
   class_payload["trainer_name"] = ""
 
@@ -165,7 +165,7 @@ def test_create_class_with_missing_trainer_name_fails(app_client):
 
 def test_create_class_with_invalid_capacity_fails(app_client):
   #Validation failed; invalid capacity
-  auth_headers = get_trainer_auth_header(app_client)
+  auth_headers = get_admin_auth_header(app_client)
   class_payload = build_valid_class()
   class_payload["capacity"] = 0
 
@@ -176,7 +176,7 @@ def test_create_class_with_invalid_capacity_fails(app_client):
 
 def test_create_class_with_negative_capacity_fails(app_client):
   #Validation failed, capacity must be a positive number
-  auth_headers = get_trainer_auth_header(app_client)
+  auth_headers = get_admin_auth_header(app_client)
   class_payload = build_valid_class()
   class_payload["capacity"] = -5
 
@@ -187,7 +187,7 @@ def test_create_class_with_negative_capacity_fails(app_client):
 
 def test_create_class_with_non_integer_capacity_fails(app_client):
   #Validation failed, capacity must be an integer
-  auth_headers = get_trainer_auth_header(app_client)
+  auth_headers = get_admin_auth_header(app_client)
   class_payload = build_valid_class()
   class_payload["capacity"] = "fifteen"
 
@@ -198,7 +198,7 @@ def test_create_class_with_non_integer_capacity_fails(app_client):
 
 def test_create_class_with_end_time_before_start_time_fails(app_client):
   #Validation failed; end_time must be after start_time
-  auth_headers = get_trainer_auth_header(app_client)
+  auth_headers = get_admin_auth_header(app_client)
   class_payload = build_valid_class()
 
   class_start_time = datetime.now()+timedelta(hours = 2) #start time is in future
@@ -215,7 +215,7 @@ def test_create_class_with_end_time_before_start_time_fails(app_client):
 
 def test_create_class_with_start_time_in_past_fails(app_client):
   #Validation failed; start_time must be in future
-  auth_headers = get_trainer_auth_header(app_client)
+  auth_headers = get_admin_auth_header(app_client)
   class_payload = build_valid_class()
 
   class_start_time = datetime.now()-timedelta(hours = 2) #start time is in past
@@ -232,7 +232,7 @@ def test_create_class_with_start_time_in_past_fails(app_client):
 
 def test_create_class_with_equal_start_time_and_end_time_fails(app_client):
   #Validation failed; end_time must strictly be after start_time, not equal to it
-  auth_headers = get_trainer_auth_header(app_client)
+  auth_headers = get_admin_auth_header(app_client)
   class_payload = build_valid_class()
 
   class_start_time = datetime.now()+timedelta(hours = 2) #start time is in future(as it should be)
@@ -250,7 +250,7 @@ def test_create_class_with_equal_start_time_and_end_time_fails(app_client):
 
 def test_create_class_outside_upcoming_two_weeks_fails(app_client):
   #Validation failed; Classes can be created only within upcoming 2 weeks
-  auth_headers = get_trainer_auth_header(app_client)
+  auth_headers = get_admin_auth_header(app_client)
   class_payload = build_valid_class()
 
   class_start_time = datetime.now() + timedelta(days = 25) #outside of allowed 2 weeks window
@@ -266,7 +266,7 @@ def test_create_class_outside_upcoming_two_weeks_fails(app_client):
 
 def test_create_class_with_invalid_datetime_format_fails(app_client):
   #Validation failed; start_time and end_time must be valid ISO datetime strings
-  auth_headers = get_trainer_auth_header(app_client)
+  auth_headers = get_admin_auth_header(app_client)
   class_payload = build_valid_class()
 
   class_payload["start_time"] = "03/11/2026 08:30" #invalid date format
@@ -296,7 +296,7 @@ def test_create_class_authenticated_member_fails(app_client):
 
 def test_create_class_with_overlapping_time_and_location_fails(app_client):
   #Validation fails; no two classes can be scheduled at same place and same time
-  auth_headers = get_trainer_auth_header(app_client)
+  auth_headers = get_admin_auth_header(app_client)
   first_class_payload = build_valid_class()
 
   first_response = app_client.post("/classes/", json = first_class_payload, headers = auth_headers)
@@ -334,8 +334,8 @@ def test_view_class_list_with_no_upcoming_classes(app_client):
 def test_view_class_list_returns_upcoming_classes_grouped_by_week(app_client):
   #if upcoming classes do exist, API should return them grouped by week
   
-  #Log in as trainer to create a class first
-  auth_headers = get_trainer_auth_header(app_client)
+  #Log in as admin to create a class first
+  auth_headers = get_admin_auth_header(app_client)
   #create a valid class
   class_payload = build_valid_class()
   create_response = app_client.post("/classes/", json = class_payload, headers = auth_headers)
@@ -363,8 +363,8 @@ def test_view_class_list_returns_upcoming_classes_grouped_by_week(app_client):
 
 def test_view_class_list_includes_full_classes(app_client):
   #full classes still appear in class list, with remaining_spots = 0
-  #Log in as trainer to create a class first
-  auth_headers = get_trainer_auth_header(app_client)
+  #Log in as admin to create a class first
+  auth_headers = get_admin_auth_header(app_client)
   #create a valid class
   class_payload = build_valid_class()
   create_response = app_client.post("/classes/", json = class_payload, headers = auth_headers)

--- a/tests/unit/test_reminders.py
+++ b/tests/unit/test_reminders.py
@@ -97,11 +97,15 @@ def get_admin_auth_header(app_client):
   login_response = app_client.post(
     "/auth/login",
     json ={
-      "email": "admin1",
+      "email": "admin1@test.com",
       "password": "password123"
     },
   )
+  assert login_response.status_code == HTTPStatus.OK
+
   access_token = login_response.json.get("access_token")
+  assert access_token is not None
+
   return {"Authorization": f"Bearer {access_token}"}
 
 def get_member_auth_header(app_client):
@@ -134,10 +138,10 @@ def get_member_auth_header(app_client):
   assert login_response.status_code == HTTPStatus.OK
 
   #Extract token and return auth header
-  acces_token = login_response.json.get("access_token")
-  assert acces_token is not None
+  access_token = login_response.json.get("access_token")
+  assert access_token is not None
 
-  return {"Authorization": f"Bearer {acces_token}"}
+  return {"Authorization": f"Bearer {access_token}"}
 
 def test_send_reminders_success(app_client, seed_data):
     with patch("app.apis.classes.send_reminder_email", return_value=True):

--- a/tests/unit/test_reminders.py
+++ b/tests/unit/test_reminders.py
@@ -92,12 +92,12 @@ def seed_data():
 
     return {"class1_id":str(class1_id), "class2_id":str(class2_id), "member_id":str(member1_id)}
 
-def get_trainer_auth_header(app_client):
-  #Log in as seeded trainer user and return valid JWT auth header
+def get_admin_auth_header(app_client):
+  #Log in as seeded admin user and return valid JWT auth header
   login_response = app_client.post(
     "/auth/login",
     json ={
-      "name": "trainer1",
+      "email": "admin1",
       "password": "password123"
     },
   )
@@ -113,7 +113,7 @@ def get_member_auth_header(app_client):
   password = "password123"
 
   #register a new member
-  register_response = app_client.post("/auth/register",
+  register_response = app_client.post("/auth/register/member",
     json = {
       "name" : username,
       "email" : email,
@@ -127,7 +127,7 @@ def get_member_auth_header(app_client):
   #Log in as that member
   login_response = app_client.post("/auth/login",
     json = {
-      "name": username,
+      "email": email,
       "password": password
     })
   #Make sure login succeded
@@ -141,13 +141,13 @@ def get_member_auth_header(app_client):
 
 def test_send_reminders_success(app_client, seed_data):
     with patch("app.apis.classes.send_reminder_email", return_value=True):
-        resp = app_client.post(f"/classes/{seed_data['class2_id']}/reminders",headers=get_trainer_auth_header(app_client))
+        resp = app_client.post(f"/classes/{seed_data['class2_id']}/reminders",headers=get_admin_auth_header(app_client))
         assert resp.status_code == 200
         assert resp.json == {MSG: "Reminders sent to 1 member(s). Failed: 2."}
 
 def test_send_reminders_failed(app_client, seed_data):
     with patch("app.apis.classes.send_reminder_email", return_value=False):
-        resp = app_client.post(f"/classes/{seed_data['class2_id']}/reminders",headers=get_trainer_auth_header(app_client))
+        resp = app_client.post(f"/classes/{seed_data['class2_id']}/reminders",headers=get_admin_auth_header(app_client))
         assert resp.status_code == 200
         assert resp.json == {MSG: "Reminders sent to 0 member(s). Failed: 3."}
 
@@ -161,11 +161,11 @@ def test_send_reminders_forbidden_for_member(app_client, seed_data):
 
 def test_send_reminders_class_not_found(app_client):
     invalid_class = str(ObjectId())
-    resp = app_client.post(f"/classes/{invalid_class}/reminders",headers=get_trainer_auth_header(app_client))
+    resp = app_client.post(f"/classes/{invalid_class}/reminders",headers=get_admin_auth_header(app_client))
     assert resp.status_code == 404
     
 def test_send_reminders_no_bookings(app_client, seed_data):
-    resp = app_client.post(f"/classes/{seed_data['class1_id']}/reminders", headers=get_trainer_auth_header(app_client))
+    resp = app_client.post(f"/classes/{seed_data['class1_id']}/reminders", headers=get_admin_auth_header(app_client))
     assert resp.status_code == 200
     assert resp.json == {MSG: "No members are registered for this class"}
 


### PR DESCRIPTION
This PR refactors authentication and role-based registration to support a clearer admin/trainer workflow while addressing code smells and design issues identified in the previous sprint.

Changes include:

- Updated login flow to use email + password instead of username. Based on previous Sprint feedback
- Split registration into separate member and trainer flows.
- Restricted trainer registration so it requires admin authorization.
- Refactored role handling using the Role enum and centralized helper methods.
- Refactored class-creation permission checks to use role-based helper logic.
- Removed dead imports and related unused code.
- Updated README with clearer instructions for testing admin and trainer flows in Swagger.

Closes #56 
