### PR TITLE
Feature 6: Create recurring classes

### DIFF
--- a/app/apis/classes.py
+++ b/app/apis/classes.py
@@ -84,6 +84,7 @@ class_create_fields = api.model(
     trainer_name: fields.String(example = _Example_class_1[trainer_name]),
     RECURRING_TYPE_FIELD: fields.String(
         required=False,
+        enum=["daily", "weekly"],
         example="daily",
         description="Recurrence pattern: daily or weekly",
     ),
@@ -150,6 +151,18 @@ class ClassList(Resource):
       "Create Class: Forbidden",
       {MSG: fields.String("Only trainers or admins can create classes")},
     ),
+  )
+
+  @api.doc(
+    description="""
+    Create a single fitness class or a recurring class series.
+
+    Optional recurrence fields:
+    - recurrence_type: "daily" or "weekly"
+    - recurrence_end_date: ISO datetime of the last occurrence
+
+    Remove recurrence_type and recurrence_end_date lines to create a single class.
+    """
   )
   def post(self):
     #Validate that request is json

--- a/app/apis/classes.py
+++ b/app/apis/classes.py
@@ -5,7 +5,10 @@ from app.db.classes import class_name, start_time, end_time, location, capacity,
 from app.db.users import UserResource, ROLE, USERNAME, EMAIL, PHONE
 from app.db.bookings import BookingResource, USER_ID
 from app.services.email import send_reminder_email
-from app.services.classes import can_user_create_class, create_class_with_validation 
+from app.services.classes import can_user_create_class, create_class_with_validation, create_recurring_classes_with_validation
+from app.services.classes import RECURRING_TYPE_FIELD, RECURRING_END_DATE_FIELD
+
+
 
 
 from http import HTTPStatus
@@ -33,6 +36,8 @@ def extract_class_data(data):
     location: data.get(location),
     capacity: data.get(capacity),
     trainer_name: data.get(trainer_name),
+    RECURRING_TYPE_FIELD: data.get(RECURRING_TYPE_FIELD),
+    RECURRING_END_DATE_FIELD: data.get(RECURRING_END_DATE_FIELD),
   }  
 
 def validate_required_string(value, error_message):
@@ -77,6 +82,16 @@ class_create_fields = api.model(
     location: fields.String(example = _Example_class_1[location]),
     capacity: fields.Integer(example = _Example_class_1[capacity]),
     trainer_name: fields.String(example = _Example_class_1[trainer_name]),
+    RECURRING_TYPE_FIELD: fields.String(
+        required=False,
+        example="daily",
+        description="Recurrence pattern: daily or weekly",
+    ),
+    RECURRING_END_DATE_FIELD: fields.String(
+        required=False,
+        example="2026-03-16T08:30:00",
+        description="Last date to generate recurring classes (ISO format).",
+    ),
   },
 )
 class_list_fields = api.model(
@@ -155,11 +170,25 @@ class ClassList(Resource):
     if validation_error:
       return validation_error
     
-    #Create class through service layer
-    class_id, creation_error = create_class_with_validation(class_data)
-    if creation_error:
-       return {MSG: creation_error}, HTTPStatus.NOT_ACCEPTABLE
-    return {MSG:f"Class created with id {class_id}"}, HTTPStatus.OK
+    recurrence_type = class_data.get(RECURRING_TYPE_FIELD)
+
+    if recurrence_type:
+      #Recurring series
+      class_ids, error = create_recurring_classes_with_validation(class_data)
+      if error:
+        return {MSG: error}, HTTPStatus.NOT_ACCEPTABLE
+
+      return {
+        MSG: f"Recurring classes created with ids {class_ids}"
+      }, HTTPStatus.OK
+    
+    else: #Single class
+      #Create class through service layer
+      class_id, creation_error = create_class_with_validation(class_data)
+      if creation_error:
+        return {MSG: creation_error}, HTTPStatus.NOT_ACCEPTABLE
+      return {MSG:f"Class created with id {class_id}"}, HTTPStatus.OK
+    
 @api.route("/<string:class_id>/members")
 class ClassMembers(Resource):
   @jwt_required()

--- a/app/services/classes.py
+++ b/app/services/classes.py
@@ -2,12 +2,19 @@ from app.db.classes import ClassResource
 from app.db.users import UserResource
 from datetime import datetime, timedelta
 from app.db.classes import class_name, start_time, end_time, location, capacity, trainer_name
+from app.services.recurrence import RecurrenceStrategy, DailyRecurrenceStrategy, WeeklyRecurrenceStrategy
 
 CLASS_WINDOW_DAYS = 14
 DATETIME_FORMAT_ERROR = "Start time and end time must be in the format YYYY-MM-DDTHH:MM:SS (e.g. 2026-03-02T08:30:00)"
 CLASS_WINDOW_ERROR = "Classes can only be created for upcoming 2 weeks"
 CLASS_END_TIME_ERROR = "End time must be after start time"
 CLASS_OVERLAP_ERROR = "Another class is already scheduled at this location during that time"
+
+RECURRING_TYPE_FIELD = "recurrence_type"
+RECURRING_END_DATE_FIELD = "recurrence_end_date"
+
+RECURRING_TYPE_ERROR = "Unsupported recurrence_type. Supported: daily, weekly"
+RECURRING_END_DATE_ERROR = "recurrence_end_date must be a valid ISO datetime and not before start_time"
 
 def can_user_create_class(user_id):
   user_res = UserResource()
@@ -32,6 +39,32 @@ def validate_class_schedule(start_datetime, end_datetime):
     return CLASS_END_TIME_ERROR
   return None 
 
+#Selects the correct recurrence algorithm at runtime based on recurrence_type from the request
+def resolve_recurrence_strategy(recurrence_type: str) -> RecurrenceStrategy | None: 
+    recurrence_type = (recurrence_type or "").strip().lower()
+    if recurrence_type == "daily":
+        return DailyRecurrenceStrategy()
+    if recurrence_type == "weekly":
+        return WeeklyRecurrenceStrategy()
+    return None
+
+def parse_series_end_date(class_data, first_start: datetime):
+    end_date_str = class_data.get(RECURRING_END_DATE_FIELD)
+    if not end_date_str:
+        #default: up to CLASS_WINDOW_DAYS from first_start
+        return first_start + timedelta(days=CLASS_WINDOW_DAYS)
+
+    try:
+        series_end = datetime.fromisoformat(end_date_str)
+    except ValueError:
+        return None
+
+    if series_end < first_start: #recurrence end must be on/after the first class start
+        return None
+
+    return series_end
+
+
 def create_class_with_validation(class_data):
   parsed_datetimes = parse_class_datetimes(class_data)
   if parsed_datetimes is None:
@@ -55,3 +88,54 @@ def create_class_with_validation(class_data):
     class_data[trainer_name]
   )
   return class_id, None
+
+
+def create_recurring_classes_with_validation(class_data):
+  recurrence_type = class_data.get(RECURRING_TYPE_FIELD)
+  strategy = resolve_recurrence_strategy(recurrence_type)
+  if strategy is None:
+      return None, RECURRING_TYPE_ERROR
+
+  #Parse first occurrence times using existing logic
+  parsed_datetimes = parse_class_datetimes(class_data)
+  if parsed_datetimes is None:
+      return None, DATETIME_FORMAT_ERROR
+  first_start, first_end = parsed_datetimes
+
+  #Reuse schedule validation for the first occurrence
+  schedule_error = validate_class_schedule(first_start, first_end)
+  if schedule_error:
+      return None, schedule_error
+
+  recurrence_end = parse_series_end_date(class_data, first_start)
+  if recurrence_end is None:
+      return None, RECURRING_END_DATE_ERROR
+
+  class_resource = ClassResource()
+
+  #Generate all occurrences via strategy
+  occurrences = strategy.generate_occurrences(first_start, first_end, recurrence_end)
+
+  created_ids: list[str] = []
+  for occ in occurrences:
+      start_date = occ["start_time"]
+      end_date = occ["end_time"]
+
+      #Enforce overlap constraints per occurrence
+      if class_resource.has_schedule_conflict(
+          class_data[location], start_date, end_date
+      ):
+          #On first conflict, stop and report error
+          return None, CLASS_OVERLAP_ERROR
+
+      class_id = class_resource.create_class(
+          class_data[class_name],
+          start_date.isoformat(),
+          end_date.isoformat(),
+          class_data[location],
+          class_data[capacity],
+          class_data[trainer_name],
+      )
+      created_ids.append(class_id)
+
+  return created_ids, None

--- a/app/services/recurrence.py
+++ b/app/services/recurrence.py
@@ -1,0 +1,42 @@
+from abc import ABC, abstractmethod
+from datetime import timedelta
+
+
+class RecurrenceStrategy(ABC): #define interface as Abstract Base Class
+    @abstractmethod #any subclass that doesn’t implement it cannot be instantiated
+    def generate_occurrences(self, first_start, first_end, recurrence_end):
+        raise NotImplementedError
+
+
+class DailyRecurrenceStrategy(RecurrenceStrategy):
+    def generate_occurrences(self, first_start, first_end, recurrence_end):
+        occurrences = []
+        current_start = first_start
+        class_duration = first_end - first_start
+
+        #Keep generating one occurrence every day until recurrence_end
+        while current_start <= recurrence_end:
+            occurrences.append({
+                "start_time": current_start,
+                "end_time": current_start + class_duration,
+            })
+            current_start += timedelta(days=1)
+
+        return occurrences
+
+
+class WeeklyRecurrenceStrategy(RecurrenceStrategy):
+    def generate_occurrences(self, first_start, first_end, recurrence_end):
+        occurrences = []
+        current_start = first_start
+        class_duration = first_end - first_start
+
+        #Keep generating one occurrence every week until recurrence_end
+        while current_start <= recurrence_end:
+            occurrences.append({
+                "start_time": current_start,
+                "end_time": current_start + class_duration,
+            })
+            current_start += timedelta(weeks=1)
+
+        return occurrences

--- a/reports/redesign.md
+++ b/reports/redesign.md
@@ -1,0 +1,27 @@
+# Redesign Report
+
+## Feature 6 : Create recurrence classes
+
+**Design Pattern**: 
+
+*Strategy* - Defines a set of algorithms, puts each into a separate class, and makes their objects interchangeable. The user is able to replace one object by another during runtime.
+
+**Why**: 
+
+Feature 6 is best suited to the Strategy pattern because recurring-class creation requires selecting one of several scheduling algorithms at runtime, such as daily or weekly generation.
+
+The system was refactored so that the API doesn't contain recurrence-specific branching logic. The service layer delegates occurrence generation to a RecurrenceStrategy implementation, while existing validation and persistence stay in the current service and ClassResource classes.
+
+This improves adherence to the Open–Closed Principle because adding a new recurrence type, such as biweekly, only requires adding another strategy class rather than modifying the existing class-creation flow.
+
+**Refactoring**:
+
+- Introduced a RecurrenceStrategy hierarchy under app/services/recurrence.py.
+- Refactored scheduling logic out of the API layer into services/classes.py (create_recurring_classes_with_validation), reusing existing validation functions.
+- Modified ClassList.post in apis/classes.py to be closed for changes: single-class creation remains unchanged, recurring logic is handled by strategies and a thin service layer.
+
+**Why it fixes previous smells**:
+
+- Avoids bloating post() with multiple recurrence branches (solves Long Method).
+- Makes recurrence extension a matter of adding a new strategy (satisfies Open–Closed).
+- Keeps scheduling logic centralized and reusable across single and recurring flows.

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,24 @@
+import os
+import pytest
+from app import create_app
+from app.db import DB
+
+@pytest.fixture(scope ="module")
+def app_client():
+  os.environ.setdefault("MONGO_URI", "mongodb://localhost/test")
+  os.environ.setdefault("DB_NAME", "test_db")
+  os.environ.setdefault("MOCK_DB", "true")
+  os.environ.setdefault("DEBUG", "true")
+
+  app = create_app()
+  app.config["TESTING"] = True
+  app.config["JWT_SECRET_KEY"] = "test-secret-key"
+
+  with app.app_context():
+    yield app.test_client()
+
+@pytest.fixture(autouse=True)
+def clear_classes_collection():
+  classes_col = DB.get_collection("classes")
+  classes_col.delete_many({})
+

--- a/tests/unit/test_classes.py
+++ b/tests/unit/test_classes.py
@@ -1,128 +1,15 @@
-#All necessary imports
-import os
 from http import HTTPStatus
 from app.apis import MSG
 from datetime import datetime, timedelta
-import pytest
-from app import create_app
 from app.db import DB
-from app.db.users import USERNAME, EMAIL, PHONE
-from app.db.users import UserResource, Role
-from werkzeug.security import generate_password_hash
+from tests.unit.test_helpers import (DEFAULT_CLASS_NAME, build_valid_class, create_class, get_member_auth_header)
 
-TEST_PASSWORD = "password123"
-DEFAULT_CLASS_NAME = "Yoga"
-DEFAULT_LOCATION = "Studio A"
-DEFAULT_PHONE = "+97150000123"
-ADMIN_PHONE = "+97150000111"
-
-@pytest.fixture(scope ="module")
-def app_client():
-  os.environ.setdefault("MONGO_URI", "mongodb://localhost/test")
-  os.environ.setdefault("DB_NAME", "test_db")
-  os.environ.setdefault("MOCK_DB", "true")
-  os.environ.setdefault("DEBUG", "true")
-
-  app = create_app()
-  app.config["TESTING"] = True
-
-  with app.app_context():
-    yield app.test_client()
-
-@pytest.fixture(autouse=True)
-def clear_classes_collection():
-  classes_col = DB.get_collection("classes")
-  classes_col.delete_many({})
-
-def get_admin_auth_header(app_client):
-  # Create admin user and return valid JWT auth header
-  user_res = UserResource()
-  unique_suffix = str(int(datetime.now().timestamp() * 1000000))
-  username = f"admin_{unique_suffix}"
-  email = f"{username}@example.com"
-  password = TEST_PASSWORD
-
-  user_res.create_user(
-    username, 
-    email, 
-    generate_password_hash(password),
-    ADMIN_PHONE,
-    role = Role.ADMIN)
-  
-  login_response = app_client.post(
-    "/auth/login",
-    json ={
-      "email": email,
-      "password": password
-    },
-  )
-  #Make sure login succeded
-  assert login_response.status_code == HTTPStatus.OK
-  #Extract token from login response
-  access_token = login_response.json.get("access_token")
-  assert access_token is not None
-
-  #Return authorisation header in JWT format
-  return {"Authorization": f"Bearer {access_token}"}
-
-def get_member_auth_header(app_client):
-  #Register new member user and return valid JWT auth header for that member
-  #Use unique username and email each time so the test does not fail
-  unique_suffix = str(int(datetime.now().timestamp() * 1000000))
-  username = f"member_{unique_suffix}"
-  email = f"{username}@example.com"
-  password = TEST_PASSWORD
-
-  #register a new member
-  register_response = app_client.post("/auth/register/member",
-    json = {
-      USERNAME : username,
-      EMAIL: email,
-      "password": password,
-      PHONE : DEFAULT_PHONE
-    },
-    )
-  #registration should suceed
-  assert register_response.status_code == HTTPStatus.CREATED
-
-  #Log in as that member
-  login_response = app_client.post("/auth/login",
-    json = {
-      "email": email,
-      "password": password
-    })
-  #Make sure login succeded
-  assert login_response.status_code == HTTPStatus.OK
-
-  #Extract token and return auth header
-  access_token = login_response.json.get("access_token")
-  assert access_token is not None
-
-  return {"Authorization": f"Bearer {access_token}"}
-
-def build_valid_class():
-  class_start_time = datetime.now()+timedelta(hours=2) #Done to ensure start date is in the future and within allowed 2-week window
-  class_end_time = class_start_time+timedelta(hours = 1)
-  return{
-    "class_name": DEFAULT_CLASS_NAME,
-    "start_time": class_start_time.isoformat(timespec="seconds"),
-    "end_time": class_end_time.isoformat(timespec="seconds"),
-    "location": DEFAULT_LOCATION,
-    "capacity": 15,
-    "trainer_name": "Emily Smith"
-  }
 
 def flatten_weekly_classes(weekly_classes):
   all_classes = []
   for classes_in_week in weekly_classes.values():
     all_classes.extend(classes_in_week)
   return all_classes
-
-def create_class(app_client, class_payload = None):
-  auth_headers = get_admin_auth_header(app_client)
-  if class_payload is None:
-    class_payload = build_valid_class()
-  return app_client.post("/classes/", json = class_payload, headers = auth_headers)
 
 
 #TESTS FOR FEATURE 1

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -1,0 +1,95 @@
+from http import HTTPStatus
+from datetime import datetime, timedelta
+from app.db.users import USERNAME, EMAIL, PHONE
+from app.db.users import UserResource, Role
+from werkzeug.security import generate_password_hash
+
+TEST_PASSWORD = "password123"
+DEFAULT_CLASS_NAME = "Yoga"
+DEFAULT_LOCATION = "Studio A"
+DEFAULT_PHONE = "+97150000123"
+ADMIN_PHONE = "+97150000111"
+
+def get_admin_auth_header(app_client):
+  # Create admin user and return valid JWT auth header
+  user_res = UserResource()
+  unique_suffix = str(int(datetime.now().timestamp() * 1000000))
+  username = f"admin_{unique_suffix}"
+  email = f"{username}@example.com"
+  password = TEST_PASSWORD
+
+  user_res.create_user(
+    username, 
+    email, 
+    generate_password_hash(password),
+    ADMIN_PHONE,
+    role = Role.ADMIN)
+  
+  login_response = app_client.post(
+    "/auth/login",
+    json ={
+      "email": email,
+      "password": password
+    },
+  )
+  #Make sure login succeded
+  assert login_response.status_code == HTTPStatus.OK
+  #Extract token from login response
+  access_token = login_response.json.get("access_token")
+  assert access_token is not None
+
+  #Return authorisation header in JWT format
+  return {"Authorization": f"Bearer {access_token}"}
+
+def get_member_auth_header(app_client):
+  #Register new member user and return valid JWT auth header for that member
+  #Use unique username and email each time so the test does not fail
+  unique_suffix = str(int(datetime.now().timestamp() * 1000000))
+  username = f"member_{unique_suffix}"
+  email = f"{username}@example.com"
+  password = TEST_PASSWORD
+
+  #register a new member
+  register_response = app_client.post("/auth/register/member",
+    json = {
+      USERNAME : username,
+      EMAIL: email,
+      "password": password,
+      PHONE : DEFAULT_PHONE
+    },
+    )
+  #registration should suceed
+  assert register_response.status_code == HTTPStatus.CREATED
+
+  #Log in as that member
+  login_response = app_client.post("/auth/login",
+    json = {
+      "email": email,
+      "password": password
+    })
+  #Make sure login succeded
+  assert login_response.status_code == HTTPStatus.OK
+
+  #Extract token and return auth header
+  access_token = login_response.json.get("access_token")
+  assert access_token is not None
+
+  return {"Authorization": f"Bearer {access_token}"}
+
+def build_valid_class():
+  class_start_time = datetime.now()+timedelta(hours=2) #Done to ensure start date is in the future and within allowed 2-week window
+  class_end_time = class_start_time+timedelta(hours = 1)
+  return{
+    "class_name": DEFAULT_CLASS_NAME,
+    "start_time": class_start_time.isoformat(timespec="seconds"),
+    "end_time": class_end_time.isoformat(timespec="seconds"),
+    "location": DEFAULT_LOCATION,
+    "capacity": 15,
+    "trainer_name": "Emily Smith"
+  }
+
+def create_class(app_client, class_payload = None):
+  auth_headers = get_admin_auth_header(app_client)
+  if class_payload is None:
+    class_payload = build_valid_class()
+  return app_client.post("/classes/", json = class_payload, headers = auth_headers)

--- a/tests/unit/test_reccurance.py
+++ b/tests/unit/test_reccurance.py
@@ -1,0 +1,57 @@
+from http import HTTPStatus
+from app.apis import MSG
+from datetime import datetime, timedelta
+from tests.unit.test_helpers import build_valid_class, create_class
+
+DAILY_RECURRENCE = "daily"
+WEEKLY_RECURRENCE = "weekly"
+RECURRENCE_END_DATE = "recurrence_end_date"
+
+
+def build_valid_recurring_class(recurrence_type):
+  class_payload = build_valid_class()
+  class_payload["recurrence_type"] = recurrence_type
+  class_payload[RECURRENCE_END_DATE] = (datetime.now()+timedelta(days=7)).isoformat(timespec="seconds")
+  return class_payload
+
+def test_create_daily_recurring_classes_success(app_client):
+  class_payload = build_valid_recurring_class(DAILY_RECURRENCE)
+  
+  response = create_class(app_client, class_payload)
+  
+  assert response.status_code == HTTPStatus.OK
+  assert "Recurring classes created with ids" in response.json[MSG]
+
+def test_create_weekly_recurring_classes_success(app_client):
+  class_payload = build_valid_recurring_class(WEEKLY_RECURRENCE)
+  
+  response = create_class(app_client, class_payload)
+  
+  assert response.status_code == HTTPStatus.OK
+  assert "Recurring classes created with ids" in response.json[MSG]
+
+def test_create_recurring_class_with_invalid_recurrence_type_fails(app_client):
+  class_payload = build_valid_recurring_class("yearly")
+  
+  response = create_class(app_client, class_payload)
+  
+  assert response.status_code == HTTPStatus.NOT_ACCEPTABLE
+
+def test_create_recurring_class_without_recurrence_type_creates_single_class(app_client):
+  class_payload = build_valid_class()
+  class_payload[RECURRENCE_END_DATE] = (
+    datetime.now() +timedelta(days = 7)
+  ).isoformat(timespec= "seconds")
+  
+  response = create_class(app_client, class_payload)
+  
+  assert response.status_code == HTTPStatus.OK
+  assert "Class created with id" in response.json[MSG]
+
+def test_create_recurring_class_with_invalid_recurrence_end_date_fails(app_client):
+  class_payload = build_valid_recurring_class(DAILY_RECURRENCE)
+  class_payload[RECURRENCE_END_DATE] = "not-a-date"
+
+  response = create_class(app_client, class_payload)
+
+  assert response.status_code == HTTPStatus.NOT_ACCEPTABLE


### PR DESCRIPTION
- Extended POST /classes/ to support optional recurring-class creation:
  - Added optional fields to the request model:
    - recurrence_type
    - recurrence_end_date
  - If recurrence_type is provided, the handler calls the recurring creation service.
  - If recurrence_type is not provided, the existing single-class path is used.

- Added recurrence logic in the service layer (Strategy design pattern):
  - Added RecurrenceStrategy base class (interface) + DailyRecurrenceStrategy and WeeklyRecurrenceStrategy.
  - Implemented create_recurring_classes_with_validation(class_data) in services/classes.py:
    - Parses first start/end time
    - Validates schedule using existing rules
    - Resolves the recurrence strategy from recurrence_type
    - Parses and validates recurrence_end_date
    - Generates all occurrences via the chosen strategy
    - Checks each occurrence for schedule conflicts
    - Creates each valid occurrence via ClassResource.create_class and returns all created ids

- Kept existing validation and role checks:
  - Reused can_user_create_class for trainer/admin authorization.
  - Reused existing date/overlap validation for both single and recurring classes.

- redesign.md updated with Feat 6 design pattern info

Closes #60 