### PR TITLE
Feature 7: Configure Notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,47 @@ Log in as a Trainer:
 - `GET /classes/{class_id}/members` (View Class Members – admin/trainer only)
 - `POST /classes/{class_id}/reminders` (Send Reminder Emails – admin/trainer only)
 
+## Notification Preferences
+
+Members can choose how they receive class reminders, via email, Telegram, or both.
+
+- On registration, notification preferences default to email using the address provided at sign-up.
+- Members can update their preferences at any time via the preferences endpoint.
+- When a trainer sends reminders for a class, each member is notified through their chosen channel(s).
+
+### Telegram Setup
+To receive Telegram notifications:
+1. Search for the bot on Telegram and send it `/start`.
+2. The bot will reply with your chat ID.
+3. Copy that chat ID and update your preferences using the endpoint below.
+
+### Endpoints
+
+**GET /notifications/preferences**
+- Auth: JWT required (member, trainer, or admin)
+- Returns the logged-in user's current notification preferences.
+- Response example:
+```json
+{"message": {"email": "user@example.com", "telegram": "123456789"}}
+```
+
+**PUT /notifications/preferences**
+- Auth: JWT required (member, trainer, or admin)
+- Updates the logged-in user's notification preferences.
+- Request body example:
+```json
+{"notification_prefs": {"email": "user@example.com", "telegram": "123456789"}}
+```
+- Supported channels: `email`, `telegram`
+
+## Telegram Configuration
+
+To enable Telegram notifications, add the following to your `.env` file:
+```
+TELEGRAM_BOT_TOKEN=your-telegram-bot-token
+```
+To get a bot token, message @BotFather on Telegram and follow the instructions to create a bot.
+
 ## Email Configuration (Amazon SES)
 
 This application uses Amazon Simple Email Service (SES) to send reminder emails.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,6 +2,7 @@ from app.apis.hello import api as hello_ns
 from app.apis.classes import api as classes_ns
 from app.apis.auth import api as auth_ns
 from app.apis.bookings import api as bookings_ns
+from app.apis.notifications import api as notifications_ns
 from werkzeug.security import generate_password_hash
 from app.db.users import UserResource, Role
 from app.config import Config
@@ -55,6 +56,7 @@ def create_app():
     api.add_namespace(classes_ns)
     api.add_namespace(auth_ns)
     api.add_namespace(bookings_ns)
+    api.add_namespace(notifications_ns)
 
     #error handlers
     @api.errorhandler(NoAuthorizationError) #handle missing Authorization header

--- a/app/apis/classes.py
+++ b/app/apis/classes.py
@@ -4,9 +4,8 @@ from app.db.classes import ClassResource
 from app.db.constants import class_name, start_time, end_time, location, capacity, remaining_spots, trainer_name
 from app.db.users import UserResource, ROLE, USERNAME, EMAIL, PHONE, NOTIFICATION_PREFS
 from app.db.bookings import BookingResource, USER_ID
-from app.services.email import send_reminder_email
 from app.services.notifications import NotificationService, ReminderData
-from app.services.classes import user_has_management_access, create_class_with_validation, validate_class, create_recurring_classes_with_validation
+from app.services.classes import user_has_management_access, create_class_with_validation, validate_class, create_recurring_classes_with_validation, is_class_in_future
 from app.services.classes import RECURRING_TYPE_FIELD, RECURRING_END_DATE_FIELD
 from app.services.bookings import get_class_members
 
@@ -271,7 +270,7 @@ class SendReminders(Resource):
       "Reminders sent",
       api.model(
           "RemindersResponse",
-          {MSG: fields.String(example="Reminders sent to 5 member(s). Failed: 0.")},
+          {MSG: fields.String(example="Notifications sent: 5, Failed: 0.")},
       ),
   )
   @api.response(
@@ -290,6 +289,15 @@ class SendReminders(Resource):
           {MSG: fields.String(example="Class not found")},
       ),
   )
+  @api.response(
+    HTTPStatus.NOT_ACCEPTABLE,
+    "Invalid Request",
+    api.model(
+        "RemindersNotAcceptable",
+        {MSG: fields.String(example="Reminders can only be sent for upcoming classes")},
+    ),
+)
+
   def post(self, class_id: str):
     access_error = validate_management_access("Only trainers or admins can send reminders")
     if access_error:
@@ -298,6 +306,9 @@ class SendReminders(Resource):
     cls, error = get_valid_class(class_id)
     if error:
       return error
+    
+    if not is_class_in_future(cls):
+      return {MSG: "Reminders can only be sent for upcoming classes"}, HTTPStatus.NOT_ACCEPTABLE
     
     members = get_class_members(class_id)
     if not members:
@@ -308,9 +319,8 @@ class SendReminders(Resource):
     total_failed = 0
 
     for member in members:
-        prefs = member.get(NOTIFICATION_PREFS) or ['email']
+        prefs = member.get(NOTIFICATION_PREFS) or {}
         reminder = ReminderData(
-            recipient_email=member.get(EMAIL),
             recipient_name=member.get(USERNAME, "Member"),
             class_name=cls.get(class_name, ""),
             start_time=cls.get(start_time, ""),

--- a/app/apis/notifications.py
+++ b/app/apis/notifications.py
@@ -1,0 +1,85 @@
+from flask_restx import Namespace, Resource, fields
+from http import HTTPStatus
+from flask import request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+from app.apis import MSG
+from app.db.users import UserResource, NOTIFICATION_PREFS, VALID_CHANNELS
+
+api = Namespace("notifications", description="Endpoint for managing notification preferences")
+
+prefs_fields = api.model(
+    "NotificationPreferences",
+    {
+        "notification_prefs": fields.Raw(
+            example={"email": "user@example.com", "telegram": "123456789"},
+            description=(
+                "Dictionary mapping channel name to contact detail. "
+                "Supported channels: 'email', 'telegram'. "
+                "Include only the channels you want to receive notifications through"
+            ),
+        )
+    },
+)
+
+@api.route("/preferences")
+class NotificationPreferences(Resource):
+    @jwt_required()
+    @api.response(
+        HTTPStatus.OK,
+        "Preferences retrieved successfully",
+        api.model("PreferencesResponse", {MSG: fields.Raw()}),
+    )
+    @api.response(
+        HTTPStatus.NOT_FOUND, 
+        "User not found",
+        api.model("PreferencesNotFound", {MSG: fields.String}))
+    
+    def get(self):
+        #Fetch user's current notification preferences
+
+        user_id = get_jwt_identity()
+        user_res = UserResource()
+        user = user_res.get_user_by_id(user_id)
+        if user is None:
+            return {MSG: "User not found"}, HTTPStatus.NOT_FOUND
+        return {MSG: user.get(NOTIFICATION_PREFS, {})}, HTTPStatus.OK
+
+
+    @jwt_required()
+    @api.expect(prefs_fields)
+    @api.response(
+        HTTPStatus.OK, 
+        "Preferences updated successfully",
+        api.model("PreferencesUpdated", {MSG: fields.String}))
+    
+    @api.response(
+        HTTPStatus.NOT_ACCEPTABLE, 
+        "Invalid request",
+        api.model("PreferencesError", {MSG: fields.String}))
+    
+    def put(self):
+        #Update the user's notification preferences
+        data = request.json
+        if data is None or not isinstance(data, dict):
+            return {MSG: "Request body must be JSON"}, HTTPStatus.NOT_ACCEPTABLE
+
+        prefs = data.get("notification_prefs")
+        if not isinstance(prefs, dict):
+            return {MSG: "notification_prefs must be a dictionary"}, HTTPStatus.NOT_ACCEPTABLE
+
+        for channel in prefs:
+            if channel not in VALID_CHANNELS:  
+                return {MSG: f"Only supported channels are accepted: {list(VALID_CHANNELS)}"}, HTTPStatus.NOT_ACCEPTABLE
+
+        for channel, contact in prefs.items():
+            if not isinstance(contact, str) or not contact.strip():
+                return {MSG: f"Contact detail for '{channel}' must be a non-empty string"}, HTTPStatus.NOT_ACCEPTABLE
+
+        user_id = get_jwt_identity()
+        user_res = UserResource()
+        updated = user_res.update_notification_prefs(user_id=user_id, prefs=prefs)
+        if not updated:
+            return {MSG: "Failed to update preferences"}, HTTPStatus.NOT_ACCEPTABLE
+
+        return {MSG: "Notification preferences updated successfully"}, HTTPStatus.OK

--- a/app/db/users.py
+++ b/app/db/users.py
@@ -14,6 +14,8 @@ PHONE = "phone"
 ROLE = "role" #"member" ,"trainer", "admin"
 NOTIFICATION_PREFS = "notification_prefs"
 
+VALID_CHANNELS = {"email", "telegram"}
+
 class Role(str, Enum):
     MEMBER = "member"
     TRAINER = "trainer"
@@ -32,7 +34,7 @@ class UserResource:
             PASSWORD_HASH: password_hash,
             PHONE: phone,
             ROLE: role.value,
-            NOTIFICATION_PREFS: notification_prefs or ["email"],
+            NOTIFICATION_PREFS: notification_prefs or {"email":email},
         }
         result = self.collection.insert_one(user)
         return str(result.inserted_id)
@@ -54,6 +56,18 @@ class UserResource:
         user = self.collection.find_one({"_id": obj_id}) 
         return serialize_item(user) 
     
+    def update_notification_prefs(self, user_id: str, prefs: dict): #Replace the user's notification_prefs with the given dict. Returns True if user was found and updated, False otherwise.
+        try:
+            obj_id = ObjectId(user_id)
+        except Exception:
+            return False
+        
+        result = self.collection.update_one(
+            {"_id": obj_id},
+            {"$set": {NOTIFICATION_PREFS: prefs}}
+        )
+        return result.matched_count > 0
+        
     def parse_role(self, role):
         if isinstance(role,Role): #if already a Role enum, use it
             return role.value

--- a/app/services/classes.py
+++ b/app/services/classes.py
@@ -68,6 +68,10 @@ def parse_series_end_date(class_data, first_start: datetime):
 
     return series_end
 
+def is_class_in_future(cls):
+  class_start = parse_class_start_time(cls)
+  if class_start is None or class_start <= datetime.now():
+    return False
 
 def create_class_with_validation(class_data):
   parsed_datetimes = parse_class_datetimes(class_data)

--- a/app/services/classes.py
+++ b/app/services/classes.py
@@ -69,9 +69,14 @@ def parse_series_end_date(class_data, first_start: datetime):
     return series_end
 
 def is_class_in_future(cls):
-  class_start = parse_class_start_time(cls)
-  if class_start is None or class_start <= datetime.now():
-    return False
+  start_time_value = cls.get(start_time)
+  if not isinstance(start_time_value, str):
+      return False
+  try:
+      class_start = datetime.fromisoformat(start_time_value)
+  except ValueError:
+      return False
+  return class_start > datetime.now()
 
 def create_class_with_validation(class_data):
   parsed_datetimes = parse_class_datetimes(class_data)

--- a/app/services/notifications.py
+++ b/app/services/notifications.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass
 from abc import ABC, abstractmethod
 from app.services.email import send_reminder_email
+from app.services.telegram import send_reminder_telegram
 
 @dataclass
 class ReminderData:
-    recipient_email: str
     recipient_name: str
     class_name: str
     start_time: str
@@ -12,16 +12,36 @@ class ReminderData:
 
 class BaseNotifier(ABC):
     @abstractmethod
-    def send(self, reminder: ReminderData) -> bool:
-        '''Sends a reminder, returns True on success and False on failure'''
+    def send(self, reminder: ReminderData, contact_details: dict) -> bool:
+        '''
+        Sends a reminder using details from contact_details
+        Returns True on success and False on failure
+        '''
 
 class EmailNotifier(BaseNotifier):
-    def send(self, reminder: ReminderData):
-        if not reminder.recipient_email:
+    def send(self, reminder: ReminderData, contact_details: dict):
+        email = contact_details.get("email")
+        if not email:
             return False
         try:
             return send_reminder_email(
-                recipient_email=reminder.recipient_email,
+                recipient_email=email,
+                recipient_name=reminder.recipient_name,
+                class_name=reminder.class_name,
+                start_time=reminder.start_time,
+                location=reminder.location,
+            )
+        except Exception:
+            return False
+        
+class TelegramNotifier(BaseNotifier):
+    def send(self, reminder: ReminderData, contact_details: dict):
+        chat_id = contact_details.get("telegram")
+        if not chat_id:
+            return False
+        try:
+            return send_reminder_email(
+                chat_id=chat_id,
                 recipient_name=reminder.recipient_name,
                 class_name=reminder.class_name,
                 start_time=reminder.start_time,
@@ -32,16 +52,20 @@ class EmailNotifier(BaseNotifier):
     
 class NotificationService:
     def __init__(self):
-        self._notifiers: dict[str, BaseNotifier] =  {"email": EmailNotifier(),}
+        self._notifiers: dict[str, BaseNotifier] =  {
+            "email": EmailNotifier(),
+            "telegram": TelegramNotifier(),
+        }
 
-    def notify(self, reminder: ReminderData, prefs: list[str]):
+    def notify(self, reminder: ReminderData, prefs: dict):
+        # Send notifications to all channels present in prefs
         sent = 0
         failed = 0
         for channel in prefs:
             notifier = self._notifiers.get(channel)
             if notifier is None:
                 continue
-            if notifier.send(reminder):
+            if notifier.send(reminder, prefs):
                 sent += 1
             else:
                 failed += 1

--- a/app/services/notifications.py
+++ b/app/services/notifications.py
@@ -1,7 +1,5 @@
 from dataclasses import dataclass
 from abc import ABC, abstractmethod
-from app.services.email import send_reminder_email
-from app.services.telegram import send_reminder_telegram
 
 @dataclass
 class ReminderData:
@@ -20,6 +18,7 @@ class BaseNotifier(ABC):
 
 class EmailNotifier(BaseNotifier):
     def send(self, reminder: ReminderData, contact_details: dict):
+        from app.services.email import send_reminder_email
         email = contact_details.get("email")
         if not email:
             return False
@@ -36,11 +35,12 @@ class EmailNotifier(BaseNotifier):
         
 class TelegramNotifier(BaseNotifier):
     def send(self, reminder: ReminderData, contact_details: dict):
+        from app.services.telegram import send_reminder_telegram
         chat_id = contact_details.get("telegram")
         if not chat_id:
             return False
         try:
-            return send_reminder_email(
+            return send_reminder_telegram(
                 chat_id=chat_id,
                 recipient_name=reminder.recipient_name,
                 class_name=reminder.class_name,

--- a/app/services/telegram.py
+++ b/app/services/telegram.py
@@ -1,0 +1,27 @@
+import requests
+from app.config import get_required_environ
+
+TELEGRAM_BOT_TOKEN = get_required_environ("TELEGRAM_BOT_TOKEN")
+TELEGRAM_API_URL = f"https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}/sendMessage"
+
+def send_reminder_telegram(chat_id: str, recipient_name: str, class_name: str, start_time: str, location: str) -> bool:
+    """
+    Send a reminder message via Telegram Bot API
+    Returns True on success, False on failure
+    """
+    text = (
+        f"Hi {recipient_name},\n\n"
+        f"This is a reminder that you are registered for {class_name}.\n"
+        f"Start time: {start_time}\n"
+        f"Location: {location}\n\n"
+        f"See you there!"
+    )
+    message_data = {
+        "chat_id": chat_id,
+        "text": text,
+    }
+    try:
+        response = requests.post(TELEGRAM_API_URL, json=message_data, timeout=10)
+        return response.status_code == 200
+    except Exception:
+        return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ boto3==1.39.8
 python-dateutil==2.9.0
 pytest
 pytest-mock
-mongomock
+mongomockrequests

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,5 @@ boto3==1.39.8
 python-dateutil==2.9.0
 pytest
 pytest-mock
-mongomockrequests
+mongomock
+requests

--- a/tests/unit/test_reminders.py
+++ b/tests/unit/test_reminders.py
@@ -8,6 +8,14 @@ from bson import ObjectId
 from flask_jwt_extended import create_access_token
 
 from app.services.email import send_reminder_email
+from app.services.telegram import send_reminder_telegram
+from app.services.notifications import (
+    NotificationService,
+    EmailNotifier,
+    TelegramNotifier,
+    BaseNotifier,
+    ReminderData,
+)
 from app.apis import MSG
 from app import create_app
 from app.db import DB
@@ -20,6 +28,7 @@ def app_client():
     os.environ.setdefault("DEBUG", "true")
     os.environ.setdefault("AWS_REGION", "us-east-1")
     os.environ.setdefault("SES_SENDER_EMAIL", "test@example.com")
+    os.environ.setdefault("TELEGRAM_BOT_TOKEN", "test-token")
     app = create_app()
     app.config["TESTING"] = True
     with app.app_context():
@@ -34,10 +43,15 @@ def seed_data():
     classes.delete_many({})
     bookings.delete_many({})
     
-    class1_id = ObjectId() # test class with no bookings
-    class2_id = ObjectId() # test class with bookings
-    member1_id = ObjectId() # test member with valid email
-    member2_id = ObjectId() # test member with no email provided
+    class1_id = ObjectId() # no bookings
+    class2_id = ObjectId() # has bookings - email only member + empty email member
+    class3_id = ObjectId()  # has bookings - multi channel members
+    past_class_id = ObjectId()  # past class
+
+    member1_id = ObjectId() # email only - valid email
+    member2_id = ObjectId() # email only - empty email
+    member3_id = ObjectId()  # telegram only
+    member4_id = ObjectId()  # both email and telegram
 
     classes.insert_many([{
         "_id": class1_id,
@@ -56,8 +70,28 @@ def seed_data():
         "location": "Dance studio",
         "capacity": 5,
         "trainer_name": "Trainer 1",
-        "remaining_spots": 4,
-    }])
+        "remaining_spots": 3,
+    },
+    {
+        "_id": class3_id,
+        "class_name": "Pilates",
+        "start_time": (datetime.now() + timedelta(days=3)).isoformat(),
+        "end_time": (datetime.now() + timedelta(days=3, hours=1)).isoformat(),
+        "location": "Studio A",
+        "capacity": 10,
+        "trainer_name": "Trainer 1",
+        "remaining_spots": 6,
+    },
+    {
+        "_id": past_class_id,
+        "class_name": "Yoga",
+        "start_time": (datetime.now() - timedelta(days=1)).isoformat(),
+        "end_time": (datetime.now() - timedelta(hours=23)).isoformat(),
+        "location": "Yoga studio",
+        "capacity": 10,
+        "trainer_name": "Trainer 1",
+        "remaining_spots": 10,
+    },])
 
     users.insert_many([{
         "_id": member1_id,
@@ -65,28 +99,52 @@ def seed_data():
         "email": "member1@example.com",
         "phone": "+97150000000",
         "role": "member",
-        "password_hash": "x"
+        "password_hash": "x",
+        "notification_prefs": {"email": "member1@example.com"},
     }, {
         "_id": member2_id,
         "name": "Test Member 2",
         "email": "",
         "phone": "+97150000001",
         "role": "member",
-        "password_hash": "x"
-    }])
+        "password_hash": "x",
+        "notification_prefs": {"email": ""},
+    },
+    {
+        "_id": member3_id,
+        "name": "Test Member 3",
+        "email": "member3@example.com",
+        "phone": "+97150000002",
+        "role": "member",
+        "password_hash": "x",
+        "notification_prefs": {"telegram": "111222333"},
+    },
+    {
+        "_id": member4_id,
+        "name": "Test Member 4",
+        "email": "member4@example.com",
+        "phone": "+97150000003",
+        "role": "member",
+        "password_hash": "x",
+        "notification_prefs": {"email": "member4@example.com", "telegram": "444555666"},
+    },])
 
-    bookings.insert_many([{
-        "user_id": str(member1_id),
-        "class_id": str(class2_id)
-    }, {
-        "user_id": str(member2_id),
-        "class_id": str(class2_id)
-    }, {
-        "user_id": ObjectId(), # covers checking for non-string member id
-        "class_id": str(class2_id)
-    }])
+    bookings.insert_many([
+        {"user_id": str(member1_id),"class_id": str(class2_id)}, 
+        {"user_id": str(member2_id),"class_id": str(class2_id)}, 
+        {"user_id": ObjectId(), "class_id": str(class2_id)}, #non string id check
+        
+        {"user_id": str(member1_id), "class_id": str(class3_id)},
+        {"user_id": str(member3_id), "class_id": str(class3_id)},
+        {"user_id": str(member4_id), "class_id": str(class3_id)},
+        {"user_id": str(member2_id), "class_id": str(class3_id)},
+    ])
 
-    return {"class1_id":str(class1_id), "class2_id":str(class2_id), "member_id":str(member1_id)}
+    return {"class1_id":str(class1_id), 
+            "class2_id":str(class2_id), 
+            "class3_id": str(class3_id),
+            "past_class_id": str(past_class_id),
+            "member1_id": str(member1_id),}
 
 def get_admin_auth_header(app_client):
   #Log in as seeded admin user and return valid JWT auth header
@@ -139,14 +197,25 @@ def get_member_auth_header(app_client):
 
   return {"Authorization": f"Bearer {access_token}"}
 
+
+def get_reminder_data():
+    return ReminderData(
+        recipient_name="Test User",
+        class_name="Yoga",
+        start_time="2026-05-01T08:00:00",
+        location="Studio B",
+    )
+
+# POST /classes/<id>/reminders
+
 def test_send_reminders_success(app_client, seed_data):
-    with patch("app.services.notifications.send_reminder_email", return_value=True):
+    with patch("app.services.email.send_reminder_email", return_value=True):
         resp = app_client.post(f"/classes/{seed_data['class2_id']}/reminders",headers=get_admin_auth_header(app_client))
         assert resp.status_code == 200
         assert resp.json == {MSG: "Notifications sent: 1, Failed: 1."}
 
 def test_send_reminders_failed(app_client, seed_data):
-    with patch("app.services.notifications.send_reminder_email", return_value=False):
+    with patch("app.services.email.send_reminder_email", return_value=False):
         resp = app_client.post(f"/classes/{seed_data['class2_id']}/reminders",headers=get_admin_auth_header(app_client))
         assert resp.status_code == 200
         assert resp.json == {MSG: "Notifications sent: 0, Failed: 2."}
@@ -169,6 +238,54 @@ def test_send_reminders_no_bookings(app_client, seed_data):
     assert resp.status_code == 200
     assert resp.json == {MSG: "No members are registered for this class"}
 
+def test_send_reminders_past_class(app_client, seed_data):
+    resp = app_client.post(f"/classes/{seed_data['past_class_id']}/reminders", headers=get_admin_auth_header(app_client),)
+    assert resp.status_code == HTTPStatus.NOT_ACCEPTABLE
+    assert resp.json == {MSG: "Reminders can only be sent for upcoming classes"}
+ 
+# GET /notifications/preferences
+ 
+def test_get_preferences(app_client):
+    #Newly registered member defaults to email only
+    resp = app_client.get("/notifications/preferences", headers=get_member_auth_header(app_client))
+    assert resp.status_code == HTTPStatus.OK
+    prefs = resp.json[MSG]
+    assert "email" in prefs
+
+# PUT /notifications/preferences
+ 
+def test_update_preferences(app_client):
+    resp = app_client.put(
+        "/notifications/preferences",
+        json={"notification_prefs": {"email": "user@example.com", "telegram": "987654321"}},
+        headers=get_member_auth_header(app_client),
+    )
+    assert resp.status_code == HTTPStatus.OK
+ 
+ 
+def test_update_preferences_invalid_channel(app_client):
+    resp = app_client.put(
+        "/notifications/preferences",
+        json={"notification_prefs": {"fax": "123"}},
+        headers=get_member_auth_header(app_client),
+    )
+    assert resp.status_code == HTTPStatus.NOT_ACCEPTABLE
+ 
+ 
+def test_update_preferences_empty_contact_detail(app_client):
+    resp = app_client.put(
+        "/notifications/preferences",
+        json={"notification_prefs": {"email": ""}},
+        headers=get_member_auth_header(app_client),
+    )
+    assert resp.status_code == HTTPStatus.NOT_ACCEPTABLE
+
+def test_update_preferences_missing_prefs_key(app_client):
+    resp = app_client.put("/notifications/preferences", json={}, headers=get_member_auth_header(app_client))
+    assert resp.status_code == HTTPStatus.NOT_ACCEPTABLE
+ 
+# send_reminder_email tests
+
 def test_send_reminder_email_success():
     with patch("app.services.email.boto3.client") as mock_boto:
         mock_ses = MagicMock()
@@ -185,6 +302,72 @@ def test_send_reminder_email_failure():
         result = send_reminder_email("test@example.com", "Test", "Yoga", "2026-03-20T08:00:00", "Yoga Studio")
         assert result == False
 
+# send_reminder_telegram tests
 
-    
+def test_send_reminder_telegram_success():
+    with patch("app.services.telegram.requests.post") as mock_post:
+        mock_post.return_value = MagicMock(status_code=200)
+        result = send_reminder_telegram("123456", "Alice", "Yoga", "2026-05-01T08:00:00", "Studio B")
+        assert result == True
+
+def test_send_reminder_telegram_code_failure():
+    with patch("app.services.telegram.requests.post") as mock_post:
+        mock_post.return_value = MagicMock(status_code=400)
+        result = send_reminder_telegram("123456", "Alice", "Yoga", "2026-05-01T08:00:00", "Studio B")
+        assert result == False
+
+def test_send_reminder_telegram_exception_failure():
+    with patch("app.services.telegram.requests.post", side_effect=Exception("timeout")):
+        result = send_reminder_telegram("123456", "Alice", "Yoga", "2026-05-01T08:00:00", "Studio B")
+        assert result == False
+
+# EmailNotifier tests
+
+def test_email_notifier_success():
+    with patch("app.services.email.send_reminder_email", return_value=True):
+        notifier = EmailNotifier()
+        assert notifier.send(get_reminder_data(), {"email": "test@example.com"}) == True
+
+def test_email_notifier_failure():
+    with patch("app.services.email.send_reminder_email", return_value=False):
+        notifier = EmailNotifier()
+        assert notifier.send(get_reminder_data(), {"email": "test@example.com"}) == False
+
+def test_email_notifier_empty_email():
+    notifier = EmailNotifier()
+    assert notifier.send(get_reminder_data(), {"email": ""}) == False
+ 
+def test_email_notifier_no_email_key():
+    notifier = EmailNotifier()
+    assert notifier.send(get_reminder_data(), {}) == False
+ 
+def test_email_notifier_exception():
+    with patch("app.services.email.send_reminder_email", side_effect=Exception("SES down")):
+        notifier = EmailNotifier()
+        assert notifier.send(get_reminder_data(), {"email": "test@example.com"}) == False
+
+# TelegramNotifier tests
+
+def test_telegram_notifier_success():
+    with patch("app.services.telegram.send_reminder_telegram", return_value=True):
+        notifier = TelegramNotifier()
+        assert notifier.send(get_reminder_data(), {"telegram": "123456"}) == True
+
+def test_telegram_notifier_failure():
+    with patch("app.services.telegram.send_reminder_telegram", return_value=False):
+        notifier = TelegramNotifier()
+        assert notifier.send(get_reminder_data(), {"telegram": "123456"}) == False
+
+def test_telegram_notifier_empty_chat_id():
+    notifier = TelegramNotifier()
+    assert notifier.send(get_reminder_data(), {"chat_id": ""}) == False
+ 
+def test_telegram_notifier_no_telegram_key():
+    notifier = TelegramNotifier()
+    assert notifier.send(get_reminder_data(), {}) == False
+ 
+def test_telegram_notifier_exception():
+    with patch("app.services.telegram.send_reminder_telegram", side_effect=Exception("network error")):
+        notifier = TelegramNotifier()
+        assert notifier.send(get_reminder_data(), {"telegram": "123456"}) == False
 


### PR DESCRIPTION
Closes #66 

## Summary
Members can now choose how they receive class reminders: email, Telegram, or both. 
Preferences are stored per user and respected when reminders are sent.

## Changes
- `app/services/telegram.py`: new Telegram sending service via Bot API
- `app/services/notifications.py`: added TelegramNotifier, simplified ReminderData, NotificationService now uses dict-based prefs
- `app/db/users.py`: notification_prefs changed to dict schema, defaults to {"email": email} on registration, added update_notification_prefs()
- `app/apis/notifications.py`: new namespace with GET/PUT /notifications/preferences
- `app/apis/classes.py`: reminders endpoint updated to use dict prefs and passes them to NotificationService, added past class check
- `tests/test_reminders.py`: updated with all Feature 7 tests
- `README.md`: documented new endpoints and Telegram setup

## Design Decision
Strategy pattern: `EmailNotifier` and `TelegramNotifier` both implement `BaseNotifier`. Adding a new channel requires only creating a new class that implements `BaseNotifier` and registering it, with no changes to existing code.

## Testing
95% statement coverage. All tests pass.