### PR TITLE
Add Docker and Gunicorn setup for backend containerization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+RUN chmod +x gunicorn_starter.sh
+
+ENTRYPOINT ["sh", "./gunicorn_starter.sh"]

--- a/README.md
+++ b/README.md
@@ -96,6 +96,22 @@ To deactivate the virtual environment:
 deactivate
 ```
 
+## Running with Docker
+
+1. Create a local `.env` file with the required environment variables.
+2. Start the backend and MongoDB containers:
+
+```bash
+docker compose up --build
+```
+
+3. Access the API at `http://localhost:8000`.
+4. Use Swagger to test endpoints.
+
+### Notes
+- The backend runs with Gunicorn in Docker.
+- MongoDB runs in a separate container through Docker Compose.
+
 ## Authentication & Testing Protected Endpoints
 
 This API uses JWT-based authentication to protect certain endpoints.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+#version: '3'
+
+services:
+  website:
+    container_name: flask-website
+    build: ./
+    ports:
+      - "8000:8000"
+    environment:
+      - MONGO_URI=${MONGO_URI}
+      - DB_NAME=${DB_NAME}
+      - MOCK_DB=${MOCK_DB}
+      - DEBUG=${DEBUG}
+      - JWT_SECRET_KEY=${JWT_SECRET_KEY}
+      - AWS_REGION=${AWS_REGION}
+      - SES_SENDER_EMAIL=${SES_SENDER_EMAIL}
+      - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}
+    depends_on:
+      - mongo
+
+  mongo:
+    image: mongo:latest
+    container_name: mongo
+    ports:
+      - "27017:27017"
+    environment:
+      - MONGO_INITDB_DATABASE=${DB_NAME}

--- a/gunicorn_starter.sh
+++ b/gunicorn_starter.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+gunicorn --bind 0.0.0.0:8000 'app:create_app()'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ mongomock==4.3.0
 coverage==7.9.1
 mypy==1.17.0
 Faker==37.5.3
+gunicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,5 @@ pytest
 pytest-mock
 mongomock
 requests
+gunicorn
+


### PR DESCRIPTION
This PR adds a complete containerization setup for the backend API using Docker, Gunicorn, and MongoDB.

- Dockerfile added & container configured to run the backend with Gunicorn:
- Added gunicorn_starter.sh to wrap the Gunicorn command.
- Docker Compose configuration ( and pass environment variables into the backend and MongoDB services)
- gunicorn is listed as a dependency
- Updated README with a short section on how to run the backend using Docker and Docker Compose

Closes #80  