### PR TITLE
fix: remove mongo container before deploy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -47,6 +47,7 @@ jobs:
               EOF
 
               docker-compose down --remove-orphans
+              docker rm -f mongo || true
               docker-compose up -d --build
               
 


### PR DESCRIPTION
The CD was failing because the mongo container from a previous run was not being cleaned up by `docker-compose down`. Added `docker rm -f mongo || true` to force remove it before bringing the stack back up.