### PR TITLE
fix: replace scp with git pull for cleaner deployments

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,42 +12,25 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Copy files to VM 
-        uses: appleboy/scp-action@v0.1.4
-        with:
-            host: ${{ secrets.HOST }}
-            username: ${{ secrets.USERNAME }}
-            port: ${{ secrets.PORT }}
-            key: ${{ secrets.KEY }}
-            source: "."
-            target: "~/app"
-
       - name: Deploy
         uses: appleboy/ssh-action@v1.0.3
         with:
-            host: ${{ secrets.HOST }}
-            username: ${{ secrets.USERNAME }}
-            port: ${{ secrets.PORT }}
-            key: ${{ secrets.KEY }}
-            script: |
-              cd ~/app
-              
-              cat > .env <<EOF
-              MONGO_URI=${{ secrets.MONGO_URI }}
-              DB_NAME=${{ secrets.DB_NAME }}
-              MOCK_DB=false
-              DEBUG=false
-              JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}
-              AWS_REGION=${{ secrets.AWS_REGION }}
-              SES_SENDER_EMAIL=${{ secrets.SES_SENDER_EMAIL }}
-              TELEGRAM_BOT_TOKEN=${{ secrets.TELEGRAM_BOT_TOKEN }}
-              EOF
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          port: ${{ secrets.PORT }}
+          key: ${{ secrets.KEY }}
+          script: |
+            cd ~/app
+            git pull origin main
 
-              docker-compose down --remove-orphans
-              docker rm -f mongo || true
-              docker-compose up -d --build
-              
+            echo "MONGO_URI=${{ secrets.MONGO_URI }}" > .env
+            echo "DB_NAME=${{ secrets.DB_NAME }}" >> .env
+            echo "MOCK_DB=false" >> .env
+            echo "DEBUG=false" >> .env
+            echo "JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}" >> .env
+            echo "AWS_REGION=${{ secrets.AWS_REGION }}" >> .env
+            echo "SES_SENDER_EMAIL=${{ secrets.SES_SENDER_EMAIL }}" >> .env
+            echo "TELEGRAM_BOT_TOKEN=${{ secrets.TELEGRAM_BOT_TOKEN }}" >> .env
 
+            docker-compose down
+            docker-compose up -d --build


### PR DESCRIPTION
Replaced file copying via scp with git pull on the VM.

- VM now pulls on each deploy
- Eliminates orphan container conflicts caused by scp overwriting files outside docker-compose's context