### PR TITLE
fix: remove stale flask-website container before deploy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,4 +36,5 @@ jobs:
             EOF
 
             docker-compose down
+            docker rm -f flask-website || true
             docker-compose up -d --build


### PR DESCRIPTION
Added `docker rm -f flask-website || true` to remove a stale container left over