### PR TITLE
Create Class Endpoint Refactors

### DIFF
--- a/app/apis/classes.py
+++ b/app/apis/classes.py
@@ -95,7 +95,7 @@ class_create_fields = api.model(
     RECURRING_END_DATE_FIELD: fields.String(
         required=False,
         example="2026-03-16T08:30:00",
-        description="Last date to generate recurring classes (ISO format).",
+        description="Date of last class in the recurrence series (ISO format).",
     ),
   },
 )
@@ -112,7 +112,7 @@ class_list_fields = api.model(
 )
 @api.route("/")
 class ClassList(Resource):
-  #Fetches list of upcoming fitness classes, endpoint used by guests, members, trainers and admins, returns all classes scheduled within upcoming 2 weeks, inlcudes full classes
+  #Fetches list of upcoming fitness classes, endpoint used by guests, members, trainers and admins, returns all classes scheduled within configured window, inlcudes full classes
   @api.response(
       HTTPStatus.OK,
       "Success",

--- a/app/apis/classes.py
+++ b/app/apis/classes.py
@@ -112,7 +112,7 @@ class_list_fields = api.model(
 )
 @api.route("/")
 class ClassList(Resource):
-  #Fetches list of upcoming fitness classes, endpoint used by guests, members, trainers and admins, returns all classes scheduled within configured window, inlcudes full classes
+  #Fetches list of upcoming fitness classes, endpoint used by guests, members, trainers and admins. Includes full classes
   @api.response(
       HTTPStatus.OK,
       "Success",
@@ -129,7 +129,7 @@ class ClassList(Resource):
       return {MSG: "No upcoming classes available"}, HTTPStatus.OK
     return {MSG: weekly_classes}, HTTPStatus.OK
   
-  #Creates a new fitness class, endpoint used by trainers and admins, validates inputs and applies upcoming 2 weeks rule
+  #Creates a new fitness class, endpoint used by trainers and admins. Validates schedule conflicts and future start times.
   @jwt_required()
   @api.expect(class_create_fields)
   @api.response(
@@ -159,13 +159,30 @@ class ClassList(Resource):
 
   @api.doc(
     description="""
-    Create a single fitness class or a recurring class series.
+    This endpoints allows for both single class creation and recurring classes creation.
 
-    Optional recurrence fields:
-    - recurrence_type: "daily" or "weekly"
-    - recurrence_end_date: ISO datetime of the last occurrence
+    Single class:
+    Omit last 2 recurrence fields and trailing comma `,`.
 
-    Remove recurrence_type and recurrence_end_date lines to create a single class.
+    Daily recurring series example for 3 days:
+    ```json
+    {
+      "class_name": "Morning Yoga",
+      "start_time": "2026-06-10T07:00:00",
+      "end_time": "2026-06-10T08:00:00",
+      "location": "Studio B",
+      "capacity": 12,
+      "trainer_name": "John Doe",
+      "recurrence_type": "daily",
+      "recurrence_end_date": "2026-06-12T08:00:00"
+    }
+    ```
+
+    Notes:
+    - `start_time`/`end_time` = class times of first class in the series
+    - `recurrence_end_date` = last day of class in the series (required with recurrence_type)
+    - Classes must start in future, no schedule overlaps
+    - Returns single class ID or list of IDs
     """
   )
   def post(self):

--- a/app/services/classes.py
+++ b/app/services/classes.py
@@ -4,9 +4,8 @@ from datetime import datetime, timedelta
 from app.db.constants import class_name, start_time, end_time, location, capacity, trainer_name
 from app.services.recurrence import RecurrenceStrategy, DailyRecurrenceStrategy, WeeklyRecurrenceStrategy
 
-CLASS_WINDOW_DAYS = 14
-DATETIME_FORMAT_ERROR = "Start time and end time must be in the format YYYY-MM-DDTHH:MM:SS (e.g. 2026-03-02T08:30:00)"
-CLASS_WINDOW_ERROR = "Classes can only be created for upcoming 2 weeks"
+DATETIME_FORMAT_ERROR = "Start time and end time must be in the format YYYY-MM-DDTHH:MM:SS (e.g. 2026-06-02T08:30:00)"
+START_TIME_ERROR = "Start time must be in the future"
 CLASS_END_TIME_ERROR = "End time must be after start time"
 CLASS_OVERLAP_ERROR = "Another class is already scheduled at this location during that time"
 
@@ -15,6 +14,7 @@ RECURRING_END_DATE_FIELD = "recurrence_end_date"
 
 RECURRING_TYPE_ERROR = "Unsupported recurrence_type. Supported: daily, weekly"
 RECURRING_END_DATE_ERROR = "recurrence_end_date must be a valid ISO datetime and not before start_time"
+RECURRING_END_DATE_REQUIRED_ERROR = "recurrence_end_date is required when recurrence_type is provided"
 
 def user_has_management_access(user_id):
   user_res = UserResource()
@@ -34,12 +34,10 @@ def parse_class_datetimes(class_data):
     return None
 
 def validate_class_schedule(start_datetime, end_datetime):
-  now = datetime.now() #current local time
-  latest_allowed = now+timedelta(days=CLASS_WINDOW_DAYS) #latest start date permitted
-  if start_datetime<now or start_datetime>latest_allowed:
-    return CLASS_WINDOW_ERROR
-  #end time must be after start time; class cannot start and end at same time
-  if end_datetime<=start_datetime:
+  now = datetime.now()
+  if start_datetime < now:
+    return START_TIME_ERROR
+  if end_datetime<=start_datetime:   #end time must be after start time; class cannot start and end at same time
     return CLASS_END_TIME_ERROR
   return None 
 
@@ -55,8 +53,7 @@ def resolve_recurrence_strategy(recurrence_type: str) -> RecurrenceStrategy | No
 def parse_series_end_date(class_data, first_start: datetime):
     end_date_str = class_data.get(RECURRING_END_DATE_FIELD)
     if not end_date_str:
-        #default: up to CLASS_WINDOW_DAYS from first_start
-        return first_start + timedelta(days=CLASS_WINDOW_DAYS)
+        return "required"
 
     try:
         series_end = datetime.fromisoformat(end_date_str)
@@ -121,6 +118,8 @@ def create_recurring_classes_with_validation(class_data):
       return None, schedule_error
 
   recurrence_end = parse_series_end_date(class_data, first_start)
+  if recurrence_end == "required":
+    return None, RECURRING_END_DATE_REQUIRED_ERROR
   if recurrence_end is None:
       return None, RECURRING_END_DATE_ERROR
 

--- a/tests/unit/test_classes.py
+++ b/tests/unit/test_classes.py
@@ -147,7 +147,7 @@ def test_create_recurring_class_requires_recurrence_end_date(app_client):
   class_payload["recurrence_type"] = "daily"
   class_payload.pop("recurrence_end_date", None)
 
-  response = app_client.post("/classes/", class_payload)
+  response = create_class(app_client, class_payload)
 
   assert response.status_code == HTTPStatus.NOT_ACCEPTABLE
   assert response.json == {MSG: "recurrence_end_date is required when recurrence_type is provided"}

--- a/tests/unit/test_classes.py
+++ b/tests/unit/test_classes.py
@@ -124,7 +124,7 @@ def test_create_class_with_start_time_in_past_fails(app_client):
   response = create_class(app_client, class_payload)
 
   assert response.status_code == HTTPStatus.NOT_ACCEPTABLE
-  assert response.json == {MSG:"Classes can only be created for upcoming 2 weeks"}
+  assert response.json == {MSG:"Start time must be in the future"}
 
 def test_create_class_with_equal_start_time_and_end_time_fails(app_client):
   #Validation failed; end_time must strictly be after start_time, not equal to it
@@ -142,20 +142,15 @@ def test_create_class_with_equal_start_time_and_end_time_fails(app_client):
   assert response.status_code == HTTPStatus.NOT_ACCEPTABLE
   assert response.json == {MSG:"End time must be after start time"}
 
-
-def test_create_class_outside_upcoming_two_weeks_fails(app_client):
+def test_create_recurring_class_requires_recurrence_end_date(app_client):
   class_payload = build_valid_class()
+  class_payload["recurrence_type"] = "daily"
+  class_payload.pop("recurrence_end_date", None)
 
-  class_start_time = datetime.now() + timedelta(days = 25) #outside of allowed 2 weeks window
-  class_end_time = class_start_time +timedelta(hours = 1) #end time remains valid
-
-  class_payload["start_time"] = class_start_time.isoformat(timespec= "seconds")
-  class_payload["end_time"] = class_end_time.isoformat(timespec= "seconds")
-
-  response = create_class(app_client, class_payload)
+  response = app_client.post("/classes/", json=class_payload)
 
   assert response.status_code == HTTPStatus.NOT_ACCEPTABLE
-  assert response.json == {MSG:"Classes can only be created for upcoming 2 weeks"}
+  assert response.json == {MSG: "recurrence_end_date is required when recurrence_type is provided"}
 
 def test_create_class_with_invalid_datetime_format_fails(app_client):
   class_payload = build_valid_class()

--- a/tests/unit/test_classes.py
+++ b/tests/unit/test_classes.py
@@ -147,7 +147,7 @@ def test_create_recurring_class_requires_recurrence_end_date(app_client):
   class_payload["recurrence_type"] = "daily"
   class_payload.pop("recurrence_end_date", None)
 
-  response = app_client.post("/classes/", json=class_payload)
+  response = app_client.post("/classes/", class_payload)
 
   assert response.status_code == HTTPStatus.NOT_ACCEPTABLE
   assert response.json == {MSG: "recurrence_end_date is required when recurrence_type is provided"}
@@ -160,7 +160,7 @@ def test_create_class_with_invalid_datetime_format_fails(app_client):
   response = create_class(app_client, class_payload)
 
   assert response.status_code == HTTPStatus.NOT_ACCEPTABLE
-  assert response.json == {MSG: "Start time and end time must be in the format YYYY-MM-DDTHH:MM:SS (e.g. 2026-03-02T08:30:00)"}
+  assert response.json == {MSG: "Start time and end time must be in the format YYYY-MM-DDTHH:MM:SS (e.g. 2026-06-02T08:30:00)"}
 
 def test_create_class_without_auth_fails(app_client):
   class_payload = build_valid_class()


### PR DESCRIPTION
- Removed 2 week limit for creating classes
- Improved api docs to make the POST class inputs clearer
- Updated unit tests in test_classes.py to reflect changes

Notes:
- GET class endpoint still has 2 week timeframe for displaying classes

Closes #92 