### PR TITLE
Fix/rm/telegram workflow

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -58,6 +58,10 @@ def create_app():
     api.add_namespace(bookings_ns)
     api.add_namespace(notifications_ns)
 
+    if os.environ.get("MOCK_DB", "false").lower() != "true":
+        from app.services.telegram_bot import start_polling
+        start_polling()
+
     #error handlers
     @api.errorhandler(NoAuthorizationError) #handle missing Authorization header
     def handle_no_authorization_error(error):

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -14,6 +14,7 @@ from flask_restx import Api
 from flask_jwt_extended import JWTManager
 from flask_jwt_extended.exceptions import NoAuthorizationError
 from werkzeug.exceptions import BadRequest
+import os
 
 def create_app():
     app = Flask(__name__)

--- a/app/apis/classes.py
+++ b/app/apis/classes.py
@@ -2,7 +2,7 @@ from flask_restx import Namespace, Resource, fields
 from app.apis import MSG
 from app.db.classes import ClassResource
 from app.db.constants import class_name, start_time, end_time, location, capacity, remaining_spots, trainer_name
-from app.db.users import UserResource, ROLE, USERNAME, EMAIL, PHONE, NOTIFICATION_PREFS
+from app.db.users import UserResource, ROLE, USERNAME, EMAIL, PHONE, NOTIFICATION_PREFS, TELEGRAM_CHAT_ID
 from app.db.bookings import BookingResource, USER_ID
 from app.services.notifications import NotificationService, ReminderData
 from app.services.classes import user_has_management_access, create_class_with_validation, validate_class, create_recurring_classes_with_validation, is_class_in_future
@@ -336,12 +336,14 @@ class SendReminders(Resource):
     total_failed = 0
 
     for member in members:
-        prefs = member.get(NOTIFICATION_PREFS) or {}
+        prefs = member.get(NOTIFICATION_PREFS) or []
         reminder = ReminderData(
             recipient_name=member.get(USERNAME, "Member"),
             class_name=cls.get(class_name, ""),
             start_time=cls.get(start_time, ""),
             location=cls.get(location, ""),
+            email=member.get(EMAIL),
+            telegram_chat_id=member.get(TELEGRAM_CHAT_ID),
         )
         sent, failed = notification_service.notify(reminder, prefs)
         total_sent += sent

--- a/app/apis/notifications.py
+++ b/app/apis/notifications.py
@@ -84,7 +84,7 @@ class NotificationPreferences(Resource):
 
         if "telegram" in prefs:
             return {
-                MSG: "Preferences updated. To activate Telegram notifications, message your registered phone number to @FitnessClassBot on Telegram."
+                MSG: "Preferences updated. To activate Telegram notifications, message your registered phone number to @FitnessClassReminder_bot on Telegram."
             }, HTTPStatus.OK
         
         return {MSG: "Notification preferences updated successfully"}, HTTPStatus.OK

--- a/app/apis/notifications.py
+++ b/app/apis/notifications.py
@@ -4,19 +4,19 @@ from flask import request
 from flask_jwt_extended import jwt_required, get_jwt_identity
 
 from app.apis import MSG
-from app.db.users import UserResource, NOTIFICATION_PREFS, VALID_CHANNELS
+from app.db.users import UserResource, NOTIFICATION_PREFS, TELEGRAM_CHAT_ID, VALID_CHANNELS
 
 api = Namespace("notifications", description="Endpoint for managing notification preferences")
 
 prefs_fields = api.model(
     "NotificationPreferences",
     {
-        "notification_prefs": fields.Raw(
-            example={"email": "user@example.com", "telegram": "123456789"},
+        "notification_prefs": fields.List(
+            fields.String,
+            example=["email", "telegram"],
             description=(
-                "Dictionary mapping channel name to contact detail. "
-                "Supported channels: 'email', 'telegram'. "
-                "Include only the channels you want to receive notifications through"
+                "List of channels to receive notifications through. "
+                "Supported channels: 'email', 'telegram'."
             ),
         )
     },
@@ -43,8 +43,12 @@ class NotificationPreferences(Resource):
         user = user_res.get_user_by_id(user_id)
         if user is None:
             return {MSG: "User not found"}, HTTPStatus.NOT_FOUND
-        return {MSG: user.get(NOTIFICATION_PREFS, {})}, HTTPStatus.OK
-
+        return {
+            MSG: {
+                "channels": user.get(NOTIFICATION_PREFS, ["email"]),
+                "telegram_linked": user.get(TELEGRAM_CHAT_ID) is not None,
+            }
+        }, HTTPStatus.OK
 
     @jwt_required()
     @api.expect(prefs_fields)
@@ -65,16 +69,12 @@ class NotificationPreferences(Resource):
             return {MSG: "Request body must be JSON"}, HTTPStatus.NOT_ACCEPTABLE
 
         prefs = data.get("notification_prefs")
-        if not isinstance(prefs, dict):
-            return {MSG: "notification_prefs must be a dictionary"}, HTTPStatus.NOT_ACCEPTABLE
+        if not isinstance(prefs, list):
+            return {MSG: "notification_prefs must be a list"}, HTTPStatus.NOT_ACCEPTABLE
 
         for channel in prefs:
             if channel not in VALID_CHANNELS:  
                 return {MSG: f"Only supported channels are accepted: {list(VALID_CHANNELS)}"}, HTTPStatus.NOT_ACCEPTABLE
-
-        for channel, contact in prefs.items():
-            if not isinstance(contact, str) or not contact.strip():
-                return {MSG: f"Contact detail for '{channel}' must be a non-empty string"}, HTTPStatus.NOT_ACCEPTABLE
 
         user_id = get_jwt_identity()
         user_res = UserResource()
@@ -82,4 +82,9 @@ class NotificationPreferences(Resource):
         if not updated:
             return {MSG: "Failed to update preferences"}, HTTPStatus.NOT_ACCEPTABLE
 
+        if "telegram" in prefs:
+            return {
+                MSG: "Preferences updated. To activate Telegram notifications, message your registered phone number to @FitnessClassBot on Telegram."
+            }, HTTPStatus.OK
+        
         return {MSG: "Notification preferences updated successfully"}, HTTPStatus.OK

--- a/app/db/users.py
+++ b/app/db/users.py
@@ -13,6 +13,7 @@ PASSWORD_HASH = "password_hash"
 PHONE = "phone"
 ROLE = "role" #"member" ,"trainer", "admin"
 NOTIFICATION_PREFS = "notification_prefs"
+TELEGRAM_CHAT_ID = "telegram_chat_id"
 
 VALID_CHANNELS = {"email", "telegram"}
 
@@ -34,7 +35,8 @@ class UserResource:
             PASSWORD_HASH: password_hash,
             PHONE: phone,
             ROLE: role.value,
-            NOTIFICATION_PREFS: notification_prefs or {"email":email},
+            NOTIFICATION_PREFS: notification_prefs or ["email"],
+            TELEGRAM_CHAT_ID: None,
         }
         result = self.collection.insert_one(user)
         return str(result.inserted_id)
@@ -55,6 +57,21 @@ class UserResource:
 
         user = self.collection.find_one({"_id": obj_id}) 
         return serialize_item(user) 
+    
+    def get_user_by_phone(self, phone: str):
+        user = self.collection.find_one({PHONE: phone})
+        return serialize_item(user)
+    
+    def save_telegram_chat_id(self, user_id: str, chat_id: str):
+        try:
+            obj_id = ObjectId(user_id)
+        except Exception:
+            return False
+        result = self.collection.update_one(
+            {"_id": obj_id},
+            {"$set": {TELEGRAM_CHAT_ID: chat_id}}
+        )
+        return result.matched_count > 0
     
     def update_notification_prefs(self, user_id: str, prefs: dict): #Replace the user's notification_prefs with the given dict. Returns True if user was found and updated, False otherwise.
         try:

--- a/app/db/users.py
+++ b/app/db/users.py
@@ -73,7 +73,7 @@ class UserResource:
         )
         return result.matched_count > 0
     
-    def update_notification_prefs(self, user_id: str, prefs: dict): #Replace the user's notification_prefs with the given dict. Returns True if user was found and updated, False otherwise.
+    def update_notification_prefs(self, user_id: str, prefs: list): #Replace the user's notification_prefs with the given list. Returns True if user was found and updated, False otherwise.
         try:
             obj_id = ObjectId(user_id)
         except Exception:

--- a/app/services/bookings.py
+++ b/app/services/bookings.py
@@ -1,5 +1,5 @@
 from app.db.bookings import BookingResource, USER_ID
-from app.db.users import UserResource, USERNAME, EMAIL, PHONE, NOTIFICATION_PREFS
+from app.db.users import UserResource, USERNAME, EMAIL, PHONE, NOTIFICATION_PREFS, TELEGRAM_CHAT_ID
 
 def get_class_members(class_id):
     booking_res = BookingResource()
@@ -21,6 +21,7 @@ def get_class_members(class_id):
             USERNAME: member.get(USERNAME),
             EMAIL: member.get(EMAIL),
             PHONE: member.get(PHONE),
-            NOTIFICATION_PREFS: member.get(NOTIFICATION_PREFS),
+            NOTIFICATION_PREFS: member.get(NOTIFICATION_PREFS) OR ["email"],
+            TELEGRAM_CHAT_ID: member.get(TELEGRAM_CHAT_ID),
         })
     return members

--- a/app/services/bookings.py
+++ b/app/services/bookings.py
@@ -21,7 +21,7 @@ def get_class_members(class_id):
             USERNAME: member.get(USERNAME),
             EMAIL: member.get(EMAIL),
             PHONE: member.get(PHONE),
-            NOTIFICATION_PREFS: member.get(NOTIFICATION_PREFS) OR ["email"],
+            NOTIFICATION_PREFS: member.get(NOTIFICATION_PREFS),
             TELEGRAM_CHAT_ID: member.get(TELEGRAM_CHAT_ID),
         })
     return members

--- a/app/services/notifications.py
+++ b/app/services/notifications.py
@@ -7,24 +7,25 @@ class ReminderData:
     class_name: str
     start_time: str
     location: str
+    email: str = None
+    telegram_chat_id: str = None
 
 class BaseNotifier(ABC):
     @abstractmethod
-    def send(self, reminder: ReminderData, contact_details: dict) -> bool:
+    def send(self, reminder: ReminderData) -> bool:
         '''
-        Sends a reminder using details from contact_details
+        Sends a reminder
         Returns True on success and False on failure
         '''
 
 class EmailNotifier(BaseNotifier):
-    def send(self, reminder: ReminderData, contact_details: dict):
+    def send(self, reminder: ReminderData):
         from app.services.email import send_reminder_email
-        email = contact_details.get("email")
-        if not email:
+        if not reminder.email:
             return False
         try:
             return send_reminder_email(
-                recipient_email=email,
+                recipient_email=reminder.email,
                 recipient_name=reminder.recipient_name,
                 class_name=reminder.class_name,
                 start_time=reminder.start_time,
@@ -34,14 +35,13 @@ class EmailNotifier(BaseNotifier):
             return False
         
 class TelegramNotifier(BaseNotifier):
-    def send(self, reminder: ReminderData, contact_details: dict):
+    def send(self, reminder: ReminderData):
         from app.services.telegram import send_reminder_telegram
-        chat_id = contact_details.get("telegram")
-        if not chat_id:
+        if not reminder.telegram_chat_id:
             return False
         try:
             return send_reminder_telegram(
-                chat_id=chat_id,
+                chat_id=reminder.telegram_chat_id,
                 recipient_name=reminder.recipient_name,
                 class_name=reminder.class_name,
                 start_time=reminder.start_time,
@@ -57,7 +57,7 @@ class NotificationService:
             "telegram": TelegramNotifier(),
         }
 
-    def notify(self, reminder: ReminderData, prefs: dict):
+    def notify(self, reminder: ReminderData, prefs: list):
         # Send notifications to all channels present in prefs
         sent = 0
         failed = 0
@@ -65,7 +65,7 @@ class NotificationService:
             notifier = self._notifiers.get(channel)
             if notifier is None:
                 continue
-            if notifier.send(reminder, prefs):
+            if notifier.send(reminder):
                 sent += 1
             else:
                 failed += 1

--- a/app/services/telegram.py
+++ b/app/services/telegram.py
@@ -2,7 +2,7 @@ import requests
 from app.config import get_required_environ
 
 TELEGRAM_BOT_TOKEN = get_required_environ("TELEGRAM_BOT_TOKEN")
-TELEGRAM_API_URL = f"https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}/sendMessage"
+TELEGRAM_API_URL = f"https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}"
 
 def send_reminder_telegram(chat_id: str, recipient_name: str, class_name: str, start_time: str, location: str) -> bool:
     """
@@ -16,12 +16,13 @@ def send_reminder_telegram(chat_id: str, recipient_name: str, class_name: str, s
         f"Location: {location}\n\n"
         f"See you there!"
     )
-    message_data = {
-        "chat_id": chat_id,
-        "text": text,
-    }
     try:
-        response = requests.post(TELEGRAM_API_URL, json=message_data, timeout=10)
+        response = requests.post(
+            f"{TELEGRAM_API_URL}/sendMessage",
+            json={"chat_id": chat_id, "text": text},
+            timeout=10
+        )
         return response.status_code == 200
     except Exception:
         return False
+    

--- a/app/services/telegram_bot.py
+++ b/app/services/telegram_bot.py
@@ -43,7 +43,7 @@ def handle_updates(updates):
         if "telegram" not in prefs:
             send_message(chat_id, "You have not enabled Telegram notifications. Update your preferences first.")
             continue
-        user_res.save_telegram_chat_id(user["id"], chat_id)
+        user_res.save_telegram_chat_id(user["_id"], chat_id)
         send_message(chat_id, "You are now set up to receive Telegram notifications!")
  
  
@@ -59,4 +59,3 @@ def poll():
 def start_polling():
     thread = threading.Thread(target=poll, daemon=True)
     thread.start()
- 

--- a/app/services/telegram_bot.py
+++ b/app/services/telegram_bot.py
@@ -36,7 +36,7 @@ def handle_updates(updates):
         # Look up user by the phone number they sent
         user = user_res.get_user_by_phone(phone)
         if user is None:
-            send_message(chat_id, "Phone number not found. Please send the phone number you registered with.")
+            send_message(chat_id, "Phone number not found. Please send your phone number in the format you registered with (eg. +97150000000).")
             continue
         # Only link if user has telegram in their preferences
         prefs = user.get(NOTIFICATION_PREFS, [])

--- a/app/services/telegram_bot.py
+++ b/app/services/telegram_bot.py
@@ -1,0 +1,62 @@
+import threading
+import requests
+from app.config import get_required_environ
+ 
+TELEGRAM_BOT_TOKEN = get_required_environ("TELEGRAM_BOT_TOKEN")
+BASE_URL = f"https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}"
+ 
+ 
+def get_updates(offset=None):
+    params = {"timeout": 30}
+    if offset:
+        params["offset"] = offset
+    try:
+        response = requests.get(f"{BASE_URL}/getUpdates", params=params, timeout=35)
+        return response.json().get("result", [])
+    except Exception:
+        return []
+ 
+ 
+def send_message(chat_id, text):
+    try:
+        requests.post(f"{BASE_URL}/sendMessage", json={"chat_id": chat_id, "text": text}, timeout=10)
+    except Exception:
+        pass
+ 
+ 
+def handle_updates(updates):
+    from app.db.users import UserResource, NOTIFICATION_PREFS
+    user_res = UserResource()
+    for update in updates:
+        message = update.get("message")
+        if not message:
+            continue
+        chat_id = str(message["chat"]["id"])
+        phone = message.get("text", "").strip()
+        # Look up user by the phone number they sent
+        user = user_res.get_user_by_phone(phone)
+        if user is None:
+            send_message(chat_id, "Phone number not found. Please send the phone number you registered with.")
+            continue
+        # Only link if user has telegram in their preferences
+        prefs = user.get(NOTIFICATION_PREFS, [])
+        if "telegram" not in prefs:
+            send_message(chat_id, "You have not enabled Telegram notifications. Update your preferences first.")
+            continue
+        user_res.save_telegram_chat_id(user["id"], chat_id)
+        send_message(chat_id, "You are now set up to receive Telegram notifications!")
+ 
+ 
+def poll():
+    offset = None
+    while True:
+        updates = get_updates(offset)
+        if updates:
+            handle_updates(updates)
+            offset = updates[-1]["update_id"] + 1
+ 
+ 
+def start_polling():
+    thread = threading.Thread(target=poll, daemon=True)
+    thread.start()
+ 

--- a/tests/unit/test_reminders.py
+++ b/tests/unit/test_reminders.py
@@ -423,4 +423,67 @@ def test_telegram_bot_valid_phone_links_chat_id(app_client, seed_data):
         users = DB.get_collection("users")
         user = users.find_one({"phone": seed_data["member3_phone"]})
         assert user["telegram_chat_id"] == "999888"
+
+def test_telegram_bot_invalid_phone(app_client):
+    from app.services.telegram_bot import handle_updates
+    with patch("app.services.telegram_bot.send_message") as mock_send:
+        updates = [{
+            "update_id": 2,
+            "message": {"chat": {"id": 111}, "text": "+00000000000"}
+        }]
+        handle_updates(updates)
+        mock_send.assert_called_once()
+        args = mock_send.call_args[0]
+        assert "not found" in args[1].lower()
+ 
+ 
+def test_telegram_bot_user_without_telegram_pref(app_client, seed_data):
+    from app.services.telegram_bot import handle_updates
+    # member1 has notification_prefs: ["email"] only
+    users = DB.get_collection("users")
+    member1 = users.find_one({"phone": "+97150000000"})
+    with patch("app.services.telegram_bot.send_message") as mock_send:
+        updates = [{
+            "update_id": 3,
+            "message": {"chat": {"id": 222}, "text": "+97150000000"}
+        }]
+        handle_updates(updates)
+        mock_send.assert_called_once()
+        args = mock_send.call_args[0]
+        assert "not enabled" in args[1].lower()
+ 
+ 
+def test_telegram_bot_no_message_in_update():
+    from app.services.telegram_bot import handle_updates
+    updates = [{"update_id": 4}] 
+    handle_updates(updates)  
+ 
+ 
+ 
+# Notification Service
+
+def test_notification_service_email_only():
+    with patch("app.services.email.send_reminder_email", return_value=True):
+        service = NotificationService()
+        sent, failed = service.notify(get_reminder_data(), ["email"])
+        assert sent == 1 and failed == 0
+ 
+ 
+def test_notification_service_telegram_only():
+    with patch("app.services.telegram.send_reminder_telegram", return_value=True):
+        service = NotificationService()
+        sent, failed = service.notify(get_reminder_data(), ["telegram"])
+        assert sent == 1 and failed == 0
+ 
+def test_notification_service_both_succeed():
+    with patch("app.services.email.send_reminder_email", return_value=True), \
+         patch("app.services.telegram.send_reminder_telegram", return_value=True):
+        service = NotificationService()
+        sent, failed = service.notify(get_reminder_data(), ["email", "telegram"])
+        assert sent == 2 and failed == 0
+ 
+def test_notification_service_empty_prefs():
+    service = NotificationService()
+    sent, failed = service.notify(get_reminder_data(), [])
+    assert sent == 0 and failed == 0
  

--- a/tests/unit/test_reminders.py
+++ b/tests/unit/test_reminders.py
@@ -458,7 +458,64 @@ def test_telegram_bot_no_message_in_update():
     updates = [{"update_id": 4}] 
     handle_updates(updates)  
  
- 
+def test_get_updates_success():
+    from app.services.telegram_bot import get_updates
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"result": [{"update_id": 1}]}
+    with patch("app.services.telegram_bot.requests.get", return_value=mock_response):
+        result = get_updates()
+        assert result == [{"update_id": 1}]
+
+def test_get_updates_with_offset():
+    from app.services.telegram_bot import get_updates
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"result": []}
+    with patch("app.services.telegram_bot.requests.get", return_value=mock_response) as mock_get:
+        get_updates(offset=5)
+        params = mock_get.call_args[1]["params"]
+        assert params["offset"] == 5
+
+def test_get_updates_exception():
+    from app.services.telegram_bot import get_updates
+    with patch("app.services.telegram_bot.requests.get", side_effect=Exception("timeout")):
+        result = get_updates()
+        assert result == []
+
+def test_send_message_success():
+    from app.services.telegram_bot import send_message
+    with patch("app.services.telegram_bot.requests.post") as mock_post:
+        send_message("123", "hello")
+        mock_post.assert_called_once()
+
+def test_send_message_exception():
+    from app.services.telegram_bot import send_message
+    with patch("app.services.telegram_bot.requests.post", side_effect=Exception("network error")):
+        send_message("123", "hello")  # should not raise
+
+def test_start_polling_starts_thread():
+    from app.services.telegram_bot import start_polling
+    with patch("app.services.telegram_bot.threading.Thread") as mock_thread:
+        mock_instance = MagicMock()
+        mock_thread.return_value = mock_instance
+        start_polling()
+        mock_thread.assert_called_once()
+        mock_instance.start.assert_called_once()
+
+def test_poll_calls_handle_updates():
+    from app.services.telegram_bot import poll
+    call_count = {"n": 0}
+    def fake_get_updates(offset=None):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return [{"update_id": 10, "message": {"chat": {"id": 1}, "text": "hi"}}]
+        raise Exception("stop")
+    with patch("app.services.telegram_bot.get_updates", side_effect=fake_get_updates), \
+         patch("app.services.telegram_bot.handle_updates") as mock_handle:
+        try:
+            poll()
+        except Exception:
+            pass
+        mock_handle.assert_called_once()
  
 # Notification Service
 

--- a/tests/unit/test_reminders.py
+++ b/tests/unit/test_reminders.py
@@ -52,6 +52,7 @@ def seed_data():
     member2_id = ObjectId() # email only - empty email
     member3_id = ObjectId()  # telegram only
     member4_id = ObjectId()  # both email and telegram
+    member5_id = ObjectId()  # telegram selected but no chat id yet
 
     classes.insert_many([{
         "_id": class1_id,
@@ -93,58 +94,78 @@ def seed_data():
         "remaining_spots": 10,
     },])
 
-    users.insert_many([{
-        "_id": member1_id,
-        "name": "Test Member 1",
-        "email": "member1@example.com",
-        "phone": "+97150000000",
-        "role": "member",
-        "password_hash": "x",
-        "notification_prefs": {"email": "member1@example.com"},
-    }, {
-        "_id": member2_id,
-        "name": "Test Member 2",
-        "email": "",
-        "phone": "+97150000001",
-        "role": "member",
-        "password_hash": "x",
-        "notification_prefs": {"email": ""},
-    },
-    {
-        "_id": member3_id,
-        "name": "Test Member 3",
-        "email": "member3@example.com",
-        "phone": "+97150000002",
-        "role": "member",
-        "password_hash": "x",
-        "notification_prefs": {"telegram": "111222333"},
-    },
-    {
-        "_id": member4_id,
-        "name": "Test Member 4",
-        "email": "member4@example.com",
-        "phone": "+97150000003",
-        "role": "member",
-        "password_hash": "x",
-        "notification_prefs": {"email": "member4@example.com", "telegram": "444555666"},
-    },])
+    users.insert_many([
+        {
+            "_id": member1_id,
+            "name": "Test Member 1",
+            "email": "member1@example.com",
+            "phone": "+97150000000",
+            "role": "member",
+            "password_hash": "x",
+            "notification_prefs": ["email"],
+            "telegram_chat_id": None,
+        },
+        {
+            "_id": member2_id,
+            "name": "Test Member 2",
+            "email": "",
+            "phone": "+97150000001",
+            "role": "member",
+            "password_hash": "x",
+            "notification_prefs": ["email"],
+            "telegram_chat_id": None,
+        },
+        {
+            "_id": member3_id,
+            "name": "Test Member 3",
+            "email": "member3@example.com",
+            "phone": "+97150000002",
+            "role": "member",
+            "password_hash": "x",
+            "notification_prefs": ["telegram"],
+            "telegram_chat_id": "111222333",
+        },
+        {
+            "_id": member4_id,
+            "name": "Test Member 4",
+            "email": "member4@example.com",
+            "phone": "+97150000003",
+            "role": "member",
+            "password_hash": "x",
+            "notification_prefs": ["email", "telegram"],
+            "telegram_chat_id": "444555666",
+        },
+        {
+            "_id": member5_id,
+            "name": "Test Member 5",
+            "email": "member5@example.com",
+            "phone": "+97150000004",
+            "role": "member",
+            "password_hash": "x",
+            "notification_prefs": ["telegram"],
+            "telegram_chat_id": None,  # selected telegram but not linked yet
+        },
+    ])
 
     bookings.insert_many([
-        {"user_id": str(member1_id),"class_id": str(class2_id)}, 
-        {"user_id": str(member2_id),"class_id": str(class2_id)}, 
-        {"user_id": ObjectId(), "class_id": str(class2_id)}, #non string id check
+        {"user_id": str(member1_id), "class_id": str(class2_id)},
+        {"user_id": str(member2_id), "class_id": str(class2_id)},
+        {"user_id": ObjectId(), "class_id": str(class2_id)},  # non-string id check
         
+        # class3: all channel combinations
         {"user_id": str(member1_id), "class_id": str(class3_id)},
         {"user_id": str(member3_id), "class_id": str(class3_id)},
         {"user_id": str(member4_id), "class_id": str(class3_id)},
         {"user_id": str(member2_id), "class_id": str(class3_id)},
+        {"user_id": str(member5_id), "class_id": str(class3_id)},
     ])
 
     return {"class1_id":str(class1_id), 
             "class2_id":str(class2_id), 
             "class3_id": str(class3_id),
             "past_class_id": str(past_class_id),
-            "member1_id": str(member1_id),}
+            "member3_phone": "+97150000002",
+            "member5_id": str(member5_id),}
 
 def get_admin_auth_header(app_client):
   #Log in as seeded admin user and return valid JWT auth header
@@ -204,6 +225,8 @@ def get_reminder_data():
         class_name="Yoga",
         start_time="2026-05-01T08:00:00",
         location="Studio B",
+        email="test@example.com",
+        telegram_chat_id="123456",
     )
 
 # POST /classes/<id>/reminders
@@ -242,48 +265,56 @@ def test_send_reminders_past_class(app_client, seed_data):
     resp = app_client.post(f"/classes/{seed_data['past_class_id']}/reminders", headers=get_admin_auth_header(app_client),)
     assert resp.status_code == HTTPStatus.NOT_ACCEPTABLE
     assert resp.json == {MSG: "Reminders can only be sent for upcoming classes"}
+
+def test_send_reminders_multi_channel_all_succeed(app_client, seed_data):
+    with patch("app.services.email.send_reminder_email", return_value=True), \
+         patch("app.services.telegram.send_reminder_telegram", return_value=True):
+        resp = app_client.post(
+            f"/classes/{seed_data['class3_id']}/reminders",
+            headers=get_admin_auth_header(app_client),
+        )
+        assert resp.status_code == HTTPStatus.OK
+        assert resp.json == {MSG: "Notifications sent: 4, Failed: 2."}
+ 
+def test_send_reminders_multi_channel_telegram_fails(app_client, seed_data):
+    with patch("app.services.email.send_reminder_email", return_value=True), \
+         patch("app.services.telegram.send_reminder_telegram", return_value=False):
+        resp = app_client.post(
+            f"/classes/{seed_data['class3_id']}/reminders",
+            headers=get_admin_auth_header(app_client),
+        )
+        assert resp.status_code == HTTPStatus.OK
+        assert resp.json == {MSG: "Notifications sent: 2, Failed: 4."}
  
 # GET /notifications/preferences
  
 def test_get_preferences(app_client):
     #Newly registered member defaults to email only
-    resp = app_client.get("/notifications/preferences", headers=get_member_auth_header(app_client))
+    headers = get_member_auth_header(app_client)
+    resp = app_client.get("/notifications/preferences", headers=headers)
     assert resp.status_code == HTTPStatus.OK
-    prefs = resp.json[MSG]
-    assert "email" in prefs
+    data = resp.json[MSG]
+    assert "email" in data["channels"]
+    assert data["telegram_linked"] == False
 
 # PUT /notifications/preferences
  
 def test_update_preferences(app_client):
     resp = app_client.put(
         "/notifications/preferences",
-        json={"notification_prefs": {"email": "user@example.com", "telegram": "987654321"}},
+        json={"notification_prefs": ["email", "telegram"]},
         headers=get_member_auth_header(app_client),
     )
     assert resp.status_code == HTTPStatus.OK
  
- 
 def test_update_preferences_invalid_channel(app_client):
     resp = app_client.put(
         "/notifications/preferences",
-        json={"notification_prefs": {"fax": "123"}},
+        json={"notification_prefs": ["fax"]},
         headers=get_member_auth_header(app_client),
     )
     assert resp.status_code == HTTPStatus.NOT_ACCEPTABLE
- 
- 
-def test_update_preferences_empty_contact_detail(app_client):
-    resp = app_client.put(
-        "/notifications/preferences",
-        json={"notification_prefs": {"email": ""}},
-        headers=get_member_auth_header(app_client),
-    )
-    assert resp.status_code == HTTPStatus.NOT_ACCEPTABLE
-
-def test_update_preferences_missing_prefs_key(app_client):
-    resp = app_client.put("/notifications/preferences", json={}, headers=get_member_auth_header(app_client))
-    assert resp.status_code == HTTPStatus.NOT_ACCEPTABLE
- 
+  
 # send_reminder_email tests
 
 def test_send_reminder_email_success():
@@ -326,48 +357,70 @@ def test_send_reminder_telegram_exception_failure():
 def test_email_notifier_success():
     with patch("app.services.email.send_reminder_email", return_value=True):
         notifier = EmailNotifier()
-        assert notifier.send(get_reminder_data(), {"email": "test@example.com"}) == True
+        assert notifier.send(get_reminder_data()) == True
 
 def test_email_notifier_failure():
     with patch("app.services.email.send_reminder_email", return_value=False):
         notifier = EmailNotifier()
-        assert notifier.send(get_reminder_data(), {"email": "test@example.com"}) == False
+        assert notifier.send(get_reminder_data()) == False
 
 def test_email_notifier_empty_email():
     notifier = EmailNotifier()
-    assert notifier.send(get_reminder_data(), {"email": ""}) == False
+    reminder = get_reminder_data()
+    reminder.email = ""
+    assert notifier.send(reminder) == False
  
 def test_email_notifier_no_email_key():
     notifier = EmailNotifier()
-    assert notifier.send(get_reminder_data(), {}) == False
- 
+    reminder = get_reminder_data()
+    reminder.email = None
+    assert notifier.send(reminder) == False
+
 def test_email_notifier_exception():
     with patch("app.services.email.send_reminder_email", side_effect=Exception("SES down")):
         notifier = EmailNotifier()
-        assert notifier.send(get_reminder_data(), {"email": "test@example.com"}) == False
+        assert notifier.send(get_reminder_data()) == False
 
 # TelegramNotifier tests
 
 def test_telegram_notifier_success():
     with patch("app.services.telegram.send_reminder_telegram", return_value=True):
         notifier = TelegramNotifier()
-        assert notifier.send(get_reminder_data(), {"telegram": "123456"}) == True
+        assert notifier.send(get_reminder_data()) == True
 
 def test_telegram_notifier_failure():
     with patch("app.services.telegram.send_reminder_telegram", return_value=False):
         notifier = TelegramNotifier()
-        assert notifier.send(get_reminder_data(), {"telegram": "123456"}) == False
+        assert notifier.send(get_reminder_data()) == False
 
+def test_telegram_notifier_no_chat_id():
+    notifier = TelegramNotifier()
+    reminder = get_reminder_data()
+    reminder.telegram_chat_id = None
+    assert notifier.send(reminder) == False
+ 
 def test_telegram_notifier_empty_chat_id():
     notifier = TelegramNotifier()
-    assert notifier.send(get_reminder_data(), {"chat_id": ""}) == False
- 
-def test_telegram_notifier_no_telegram_key():
-    notifier = TelegramNotifier()
-    assert notifier.send(get_reminder_data(), {}) == False
- 
+    reminder = get_reminder_data()
+    reminder.telegram_chat_id = ""
+    assert notifier.send(reminder) == False
+  
 def test_telegram_notifier_exception():
     with patch("app.services.telegram.send_reminder_telegram", side_effect=Exception("network error")):
         notifier = TelegramNotifier()
-        assert notifier.send(get_reminder_data(), {"telegram": "123456"}) == False
+        assert notifier.send(get_reminder_data()) == False
 
+# Telegram bot polling tests
+
+def test_telegram_bot_valid_phone_links_chat_id(app_client, seed_data):
+    from app.services.telegram_bot import handle_updates
+    with patch("app.services.telegram_bot.send_message"):
+        updates = [{
+            "update_id": 1,
+            "message": {"chat": {"id": 999888}, "text": seed_data["member3_phone"]}
+        }]
+        handle_updates(updates)
+        users = DB.get_collection("users")
+        user = users.find_one({"phone": seed_data["member3_phone"]})
+        assert user["telegram_chat_id"] == "999888"
+ 


### PR DESCRIPTION
Closes #94 

Implemented bot polling service that automatically links a user's Telegram to their account 
when they message the bot with their registered phone number.

## Changes
- `app/db/users.py`: notification_prefs is now a list, telegram_chat_id is separate field
- `app/services/telegram_bot.py`: new polling service, maps phone number to chat_id
- `app/__init__.py`: starts polling thread on app startup in production
- `app/services/notifications.py`: notifiers read from ReminderData fields directly
- `app/services/bookings.py`: returns telegram_chat_id in member dict
- `app/apis/notifications.py`: accepts list of channels, returns bot activation instructions
- `app/apis/classes.py`: passes email and telegram_chat_id into ReminderData
- `tests/unit/test_reminders.py`: updated for new flow including bot polling tests

## Testing
All tests pass. Coverage maintained above 90%